### PR TITLE
Auto-update data/index.json on every save

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -1,9 +1,11 @@
 {
-    "max_per_file": 500,
-    "files": [
-        {
-            "name": "data_001.jsonl",
-            "count": 774
-        }
-    ]
+  "max_per_file": 800,
+  "total": 778,
+  "last_updated": "2026-04-16T15:18:09Z",
+  "files": [
+    {
+      "name": "data_001.jsonl",
+      "count": 778
+    }
+  ]
 }

--- a/scripts/core/data_store.py
+++ b/scripts/core/data_store.py
@@ -128,9 +128,30 @@ def save_main(records: list[dict]):
         new_paths.add(os.path.normpath(path))
         save_jsonl(path, chunk)
 
+    _save_index(chunks)
+
     for old in _shard_paths():
         if os.path.normpath(old) not in new_paths:
             os.remove(old)
+
+
+def _save_index(chunks: list[list[dict]]):
+    """Write data/index.json with shard metadata."""
+    index = {
+        "max_per_file": MAX_RECORDS_PER_FILE,
+        "total": sum(len(c) for c in chunks),
+        "last_updated": now_iso(),
+        "files": [
+            {"name": f"{SHARD_PREFIX}{i:03d}.jsonl", "count": len(c)}
+            for i, c in enumerate(chunks, start=1)
+        ],
+    }
+    path = os.path.join(DATA_DIR, "index.json")
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    os.replace(tmp, path)
 
 def load_temp() -> list[dict]:
     return load_jsonl(TEMP_JSONL)


### PR DESCRIPTION
## Summary
- Add `_save_index()` to `data_store.py`, called inside `save_main()`
- `index.json` now auto-updates after any operation (ingest, update, purge, delete, refetch)
- No other scripts need changes — all go through `save_main()`

## Test plan
- [x] `save_main()` writes correct `index.json` (total=778, max_per_file=800)
- [x] Atomic write via `.tmp` + `os.replace()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)