### PR TITLE
Phase 2: GitHub auth + edit drawer + add (single & bulk)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -67,9 +67,19 @@ web/
 
 ## Roadmap
 
-- **Phase 1 (this commit)** — read-only browse, search/filter, 4 MVP charts (KPI, Top Online bar, Genre treemap, Platforms donut), GitHub Pages deploy.
-- **Phase 2** — OAuth Device Flow login, single-record edit (manual fields), single Steam-link add via `scripts/temp_info.jsonl` queue, diff viewer, conflict resolution.
-- **Phase 3** — bulk add/edit/delete, remaining 8 charts (heatmap, word cloud, stacked AC, etc.), PWA, i18n vi/en, command palette, activity feed, optional Tauri desktop wrap.
+- **Phase 1** ✅ — read-only browse, search/filter, 4 MVP charts (KPI, Top Online bar, Genre treemap, Platforms donut), GitHub Pages deploy.
+- **Phase 2** ✅ — PAT-based GitHub auth (Classic PATs auto-sign as "Verified"), single-record edit drawer for the 8 manual fields, diff viewer, single + bulk Steam-link queue via `scripts/temp_info.jsonl`, conflict-retry on PUT, toast notifications.
+- **Phase 3** — bulk edit/delete, remaining 8 charts (heatmap, word cloud, stacked AC, histograms), PWA, i18n vi/en, command palette, activity feed, optional Tauri desktop wrap. Optional: OAuth Device Flow path (requires registering a GitHub OAuth App for the CLIENT_ID).
+
+## Auth & editing
+
+Editing requires a GitHub personal access token. Sign in via **Settings → Sign in**:
+
+1. Create a [Classic PAT](https://github.com/settings/tokens/new?scopes=repo,workflow&description=F2P%20Tracker%20Web%20App) with scopes `repo` + `workflow`.
+2. Paste it into the sign-in form. The token is verified against `/user` and the repo's permissions, then stored in `localStorage`.
+3. Edits commit to `data/data_00X.jsonl` shards. Adds queue into `scripts/temp_info.jsonl`, which auto-triggers the existing `ingest-new.yml` workflow to fetch full Steam metadata.
+
+Classic PATs produce GitHub-signed "Verified" commits (because GitHub web-flow signs server-side). Fine-grained PATs work too, but commits won't have the Verified badge.
 
 ## Schema sync
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,6 +33,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.27.0",
+        "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^4.5.5"
@@ -3813,6 +3814,16 @@
       "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
       "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
+    "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^4.5.5"

--- a/web/src/components/auth/AuthPanel.tsx
+++ b/web/src/components/auth/AuthPanel.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+import { Github, LogOut, ShieldCheck, AlertCircle, ExternalLink } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Badge } from "../ui/badge";
+import { Label } from "../ui/label";
+import { useAuth } from "../../stores/auth";
+import { REPO_OWNER, REPO_NAME } from "../../lib/schema";
+
+export function AuthPanel() {
+  const auth = useAuth();
+  const [token, setToken] = useState("");
+  const [showToken, setShowToken] = useState(false);
+
+  useEffect(() => {
+    if (auth.token && !auth.user && !auth.isVerifying) {
+      auth.hydrate();
+    }
+  }, [auth.token, auth.user, auth.isVerifying]);
+
+  if (auth.isAuthenticated && auth.user) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>GitHub authentication</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-3">
+            <img
+              src={auth.user.avatar_url}
+              alt=""
+              className="h-12 w-12 rounded-full border"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold">{auth.user.name ?? auth.user.login}</span>
+                <Badge variant="success">
+                  <ShieldCheck className="mr-1 h-3 w-3" /> {auth.permission ?? "write"}
+                </Badge>
+              </div>
+              <a
+                href={auth.user.html_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                @{auth.user.login}
+              </a>
+            </div>
+            <Button variant="outline" size="sm" onClick={auth.signOut}>
+              <LogOut className="mr-1 h-3 w-3" /> Sign out
+            </Button>
+          </div>
+
+          <div className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+            <p>
+              Edits, adds, and deletes commit to{" "}
+              <code className="rounded bg-muted px-1">
+                {REPO_OWNER}/{REPO_NAME}
+              </code>{" "}
+              under your account. Classic PATs auto-sign commits as "Verified".
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!token.trim()) return;
+    try {
+      await auth.signIn(token.trim());
+      setToken("");
+    } catch {
+      /* error already in auth.error */
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sign in to GitHub</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Edit, add, or delete games requires a GitHub personal access token. Read-only
+          browse works without sign-in.
+        </p>
+
+        <form onSubmit={submit} className="space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="pat">Personal access token</Label>
+            <div className="flex gap-2">
+              <Input
+                id="pat"
+                type={showToken ? "text" : "password"}
+                placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                disabled={auth.isVerifying}
+                autoComplete="off"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setShowToken((s) => !s)}
+              >
+                {showToken ? "Hide" : "Show"}
+              </Button>
+            </div>
+          </div>
+
+          {auth.error && (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+              <span>{auth.error}</span>
+            </div>
+          )}
+
+          <Button type="submit" disabled={!token.trim() || auth.isVerifying}>
+            <Github className="mr-1 h-3 w-3" />
+            {auth.isVerifying ? "Verifying…" : "Sign in"}
+          </Button>
+        </form>
+
+        <div className="space-y-2 rounded-md border bg-muted/30 p-3 text-xs">
+          <p className="font-semibold">How to create a token</p>
+          <ol className="ml-4 list-decimal space-y-1 text-muted-foreground">
+            <li>
+              Go to{" "}
+              <a
+                href="https://github.com/settings/tokens/new?scopes=repo,workflow&description=F2P%20Tracker%20Web%20App"
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary hover:underline"
+              >
+                Settings → Developer settings → Tokens (classic) <ExternalLink className="inline h-3 w-3" />
+              </a>
+            </li>
+            <li>
+              Select scopes: <code className="rounded bg-muted px-1">repo</code> and{" "}
+              <code className="rounded bg-muted px-1">workflow</code>
+            </li>
+            <li>Set expiration (90 days recommended)</li>
+            <li>Generate, copy, paste above</li>
+          </ol>
+          <p className="text-muted-foreground">
+            <strong>Verified commits:</strong> Classic PATs sign commits via GitHub
+            web-flow. Fine-grained PATs do not — but you can still edit, just without the
+            "Verified" badge.
+          </p>
+          <p className="text-muted-foreground">
+            <strong>Storage:</strong> Token is kept only in your browser&apos;s localStorage.
+            Never sent anywhere except to <code>api.github.com</code>.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/games/DiffViewer.tsx
+++ b/web/src/components/games/DiffViewer.tsx
@@ -1,0 +1,62 @@
+import type { EditPatch } from "../../lib/edits";
+import type { GameRecord } from "../../lib/schema";
+import { cn } from "../../lib/utils";
+
+interface Props {
+  before: GameRecord;
+  patch: EditPatch;
+}
+
+function fmt(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined || v === "") return "—";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  return String(v);
+}
+
+export function DiffViewer({ before, patch }: Props) {
+  const changes: { field: string; old: unknown; new: unknown }[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) continue;
+    const oldVal = (before as unknown as Record<string, unknown>)[key];
+    if (oldVal === value) continue;
+    changes.push({ field: key, old: oldVal, new: value });
+  }
+
+  if (changes.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground">
+        No changes.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 text-left">Field</th>
+            <th className="px-3 py-2 text-left">Before</th>
+            <th className="px-3 py-2 text-left">After</th>
+          </tr>
+        </thead>
+        <tbody>
+          {changes.map((c) => (
+            <tr key={c.field} className="border-t">
+              <td className="px-3 py-2 font-mono text-xs text-muted-foreground">
+                {c.field}
+              </td>
+              <td className={cn("px-3 py-2", "bg-rose-500/10 text-rose-300")}>
+                {fmt(c.old)}
+              </td>
+              <td className={cn("px-3 py-2", "bg-emerald-500/10 text-emerald-300")}>
+                {fmt(c.new)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/games/EditGameDrawer.tsx
+++ b/web/src/components/games/EditGameDrawer.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Save, AlertCircle, ExternalLink } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import { Label } from "../ui/label";
+import { Separator } from "../ui/separator";
+import { Badge } from "../ui/badge";
+import { DiffViewer } from "./DiffViewer";
+import { useAuth } from "../../stores/auth";
+import { useGames } from "../../hooks/useGames";
+import { extractAppid } from "../../lib/data-store";
+import { updateGameWithRetry, type EditPatch } from "../../lib/edits";
+import { ConflictError } from "../../lib/github-api";
+import type { GameRecord } from "../../lib/schema";
+
+interface Props {
+  game: GameRecord | null;
+  onClose: () => void;
+}
+
+interface FormState {
+  genre: string;
+  type_game: "online" | "offline" | "";
+  anti_cheat: string;
+  anti_cheat_note: string;
+  is_kernel_ac: "yes" | "no" | "unknown";
+  notes: string;
+  safe: "y" | "n" | "?" | "";
+  status: "active" | "delisted";
+}
+
+function gameToForm(g: GameRecord): FormState {
+  return {
+    genre: g.genre ?? "",
+    type_game: (g.type_game as FormState["type_game"]) ?? "",
+    anti_cheat: g.anti_cheat ?? "",
+    anti_cheat_note: g.anti_cheat_note ?? "",
+    is_kernel_ac:
+      g.is_kernel_ac === true ? "yes" : g.is_kernel_ac === false ? "no" : "unknown",
+    notes: g.notes ?? "",
+    safe: (g.safe as FormState["safe"]) ?? "?",
+    status: (g.status === "delisted" ? "delisted" : "active") as FormState["status"],
+  };
+}
+
+function formToPatch(g: GameRecord, form: FormState): EditPatch {
+  const patch: EditPatch = {};
+  const isKernelAC =
+    form.is_kernel_ac === "yes" ? true : form.is_kernel_ac === "no" ? false : null;
+
+  if (form.genre !== (g.genre ?? "")) patch.genre = form.genre;
+  if (form.type_game !== (g.type_game ?? "")) patch.type_game = form.type_game;
+  if (form.anti_cheat !== (g.anti_cheat ?? "")) patch.anti_cheat = form.anti_cheat;
+  if (form.anti_cheat_note !== (g.anti_cheat_note ?? ""))
+    patch.anti_cheat_note = form.anti_cheat_note;
+  if (isKernelAC !== (g.is_kernel_ac ?? null)) patch.is_kernel_ac = isKernelAC;
+  if (form.notes !== (g.notes ?? "")) patch.notes = form.notes;
+  if (form.safe !== (g.safe ?? "?")) patch.safe = form.safe;
+  if (form.status !== (g.status === "delisted" ? "delisted" : "active"))
+    patch.status = form.status;
+  return patch;
+}
+
+export function EditGameDrawer({ game, onClose }: Props) {
+  const auth = useAuth();
+  const games = useGames();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<FormState | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setForm(game ? gameToForm(game) : null);
+    setShowConfirm(false);
+    setSaving(false);
+  }, [game]);
+
+  const flatIndex = useMemo(() => {
+    if (!game || !games.data) return -1;
+    const aid = extractAppid(game.link);
+    if (!aid) return -1;
+    return games.data.appidIndex.get(aid) ?? -1;
+  }, [game, games.data]);
+
+  const patch = useMemo(() => {
+    if (!game || !form) return {};
+    return formToPatch(game, form);
+  }, [game, form]);
+
+  const hasChanges = Object.keys(patch).length > 0;
+
+  if (!game || !form) return null;
+
+  if (!auth.isAuthenticated) {
+    return (
+      <Dialog open onOpenChange={(o) => !o && onClose()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Sign in required</DialogTitle>
+            <DialogDescription>
+              Editing requires GitHub authentication. Go to Settings → Sign in.
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  async function save() {
+    if (!auth.token || !game || !games.data || flatIndex === -1) return;
+    setSaving(true);
+    try {
+      const result = await updateGameWithRetry({
+        record: game,
+        patch,
+        flatIndex,
+        index: games.data.index,
+        token: auth.token,
+        triggerMarkdownRebuild: true,
+      });
+      toast.success("Saved · " + result.commitSha.slice(0, 7), {
+        description: result.shard,
+        action: {
+          label: "View commit",
+          onClick: () => window.open(result.htmlUrl, "_blank"),
+        },
+      });
+      // Invalidate cache so next refetch pulls fresh data
+      await queryClient.invalidateQueries({ queryKey: ["games"] });
+      onClose();
+    } catch (err) {
+      if (err instanceof ConflictError) {
+        toast.error("Conflict — data changed remotely", {
+          description: "Refetch and re-apply your edits.",
+        });
+        await queryClient.invalidateQueries({ queryKey: ["games"] });
+        onClose();
+      } else {
+        toast.error("Save failed", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => (f ? { ...f, [key]: value } : f));
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit · {game.name || extractAppid(game.link)}</DialogTitle>
+          <DialogDescription>
+            Manual fields only. Auto-fetched data (name, reviews, players, etc.) is
+            updated by the daily pipeline.{" "}
+            <a
+              href={game.link}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              Open on Steam <ExternalLink className="h-3 w-3" />
+            </a>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="genre">Genre</Label>
+              <Input
+                id="genre"
+                value={form.genre}
+                onChange={(e) => update("genre", e.target.value)}
+                placeholder="FPS, MOBA, …"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="type_game">Type</Label>
+              <select
+                id="type_game"
+                value={form.type_game}
+                onChange={(e) =>
+                  update("type_game", e.target.value as FormState["type_game"])
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+              >
+                <option value="">— unknown —</option>
+                <option value="online">online</option>
+                <option value="offline">offline</option>
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="anti_cheat">Anti-cheat</Label>
+              <Input
+                id="anti_cheat"
+                value={form.anti_cheat}
+                onChange={(e) => update("anti_cheat", e.target.value)}
+                placeholder="VAC, EAC, BattlEye, … or - if none"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Kernel-level AC?</Label>
+              <div className="flex gap-1.5">
+                {(["unknown", "no", "yes"] as const).map((v) => (
+                  <Button
+                    key={v}
+                    type="button"
+                    size="sm"
+                    variant={form.is_kernel_ac === v ? "default" : "outline"}
+                    onClick={() => update("is_kernel_ac", v)}
+                  >
+                    {v}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="anti_cheat_note">Anti-cheat note</Label>
+            <Textarea
+              id="anti_cheat_note"
+              value={form.anti_cheat_note}
+              onChange={(e) => update("anti_cheat_note", e.target.value)}
+              placeholder="Notes on AC behavior, kernel driver, etc."
+              rows={2}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea
+              id="notes"
+              value={form.notes}
+              onChange={(e) => update("notes", e.target.value)}
+              placeholder="Personal review or comment"
+              rows={3}
+            />
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="safe">Safe?</Label>
+              <select
+                id="safe"
+                value={form.safe}
+                onChange={(e) => update("safe", e.target.value as FormState["safe"])}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+              >
+                <option value="?">unknown</option>
+                <option value="y">yes</option>
+                <option value="n">no</option>
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="status">Status</Label>
+              <select
+                id="status"
+                value={form.status}
+                onChange={(e) =>
+                  update("status", e.target.value as FormState["status"])
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+              >
+                <option value="active">active</option>
+                <option value="delisted">delisted</option>
+              </select>
+            </div>
+          </div>
+
+          {showConfirm && (
+            <>
+              <Separator />
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Diff preview</Label>
+                  <Badge variant="secondary">
+                    {Object.keys(patch).length} field
+                    {Object.keys(patch).length === 1 ? "" : "s"}
+                  </Badge>
+                </div>
+                <DiffViewer before={game} patch={patch} />
+              </div>
+            </>
+          )}
+
+          {!hasChanges && form && (
+            <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-2 text-xs text-muted-foreground">
+              <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+              <span>No changes yet — adjust a field above to enable Save.</span>
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={saving}>
+              Cancel
+            </Button>
+            {!showConfirm ? (
+              <Button
+                onClick={() => setShowConfirm(true)}
+                disabled={!hasChanges}
+              >
+                <Save className="mr-1 h-3 w-3" /> Review changes
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowConfirm(false)}
+                  disabled={saving}
+                >
+                  Back
+                </Button>
+                <Button onClick={save} disabled={saving || !hasChanges}>
+                  <Save className="mr-1 h-3 w-3" />
+                  {saving ? "Saving…" : "Commit & save"}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/games/GameDetailDrawer.tsx
+++ b/web/src/components/games/GameDetailDrawer.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -7,6 +8,7 @@ import {
 } from "../ui/dialog";
 import { Badge } from "../ui/badge";
 import { Separator } from "../ui/separator";
+import { Button } from "../ui/button";
 import {
   ExternalLink,
   Calendar,
@@ -15,6 +17,7 @@ import {
   Shield,
   Globe,
   Tag,
+  Pencil,
 } from "lucide-react";
 import {
   formatNumber,
@@ -24,6 +27,8 @@ import {
 } from "../../lib/utils";
 import { extractAppid } from "../../lib/data-store";
 import type { GameRecord } from "../../lib/schema";
+import { EditGameDrawer } from "./EditGameDrawer";
+import { useAuth } from "../../stores/auth";
 
 interface Props {
   game: GameRecord | null;
@@ -51,6 +56,9 @@ function Field({
 }
 
 export function GameDetailDrawer({ game, onClose }: Props) {
+  const auth = useAuth();
+  const [editing, setEditing] = useState(false);
+
   return (
     <Dialog open={!!game} onOpenChange={(o) => !o && onClose()}>
       <DialogContent>
@@ -64,7 +72,18 @@ export function GameDetailDrawer({ game, onClose }: Props) {
                   className="h-44 w-full rounded-md object-cover"
                 />
               )}
-              <DialogTitle className="text-xl">{game.name || "—"}</DialogTitle>
+              <div className="flex items-start justify-between gap-3">
+                <DialogTitle className="text-xl">{game.name || "—"}</DialogTitle>
+                {auth.isAuthenticated && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setEditing(true)}
+                  >
+                    <Pencil className="mr-1 h-3 w-3" /> Edit
+                  </Button>
+                )}
+              </div>
               <DialogDescription>
                 <a
                   href={game.link}
@@ -202,6 +221,9 @@ export function GameDetailDrawer({ game, onClose }: Props) {
           </div>
         )}
       </DialogContent>
+      {editing && (
+        <EditGameDrawer game={game} onClose={() => setEditing(false)} />
+      )}
     </Dialog>
   );
 }

--- a/web/src/components/layout/Topbar.tsx
+++ b/web/src/components/layout/Topbar.tsx
@@ -1,9 +1,12 @@
-import { Search, Sun, Moon, Monitor } from "lucide-react";
+import { Search, Sun, Moon, Monitor, ShieldCheck } from "lucide-react";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
 import { useFilters } from "../../stores/filters";
 import { useGames } from "../../hooks/useGames";
+import { useAuth } from "../../stores/auth";
 import { formatNumber } from "../../lib/utils";
 
 type Theme = "light" | "dark" | "system";
@@ -23,6 +26,7 @@ export function Topbar() {
   const search = useFilters((s) => s.search);
   const setSearch = useFilters((s) => s.setSearch);
   const games = useGames();
+  const auth = useAuth();
   const [theme, setTheme] = useState<Theme>(
     (localStorage.getItem("f2p:theme") as Theme) ?? "dark",
   );
@@ -31,6 +35,12 @@ export function Topbar() {
     applyTheme(theme);
     localStorage.setItem("f2p:theme", theme);
   }, [theme]);
+
+  useEffect(() => {
+    if (auth.token && !auth.user && !auth.isVerifying) {
+      void auth.hydrate();
+    }
+  }, [auth.token, auth.user, auth.isVerifying, auth]);
 
   const total = games.data?.records.length ?? 0;
   const lastUpdated = games.data?.index.last_updated ?? "";
@@ -57,6 +67,30 @@ export function Topbar() {
           </span>
         )}
       </div>
+
+      {auth.isAuthenticated && auth.user ? (
+        <Link
+          to="/settings"
+          className="hidden items-center gap-2 rounded-md border bg-card px-2 py-1 text-xs hover:bg-accent md:flex"
+          title={`Signed in as @${auth.user.login}`}
+        >
+          <img
+            src={auth.user.avatar_url}
+            alt=""
+            className="h-5 w-5 rounded-full"
+          />
+          <span className="font-medium">@{auth.user.login}</span>
+          <Badge variant="success" className="px-1.5 py-0">
+            <ShieldCheck className="h-3 w-3" />
+          </Badge>
+        </Link>
+      ) : (
+        <Link to="/settings">
+          <Button variant="outline" size="sm" className="hidden md:inline-flex">
+            Sign in
+          </Button>
+        </Link>
+      )}
 
       <div className="flex items-center gap-1">
         <Button

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cn } from "../../lib/utils";
+
+export const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-xs font-medium uppercase tracking-wider text-muted-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import { cn } from "../../lib/utils";
+
+export const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted",
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root.displayName;

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Textarea.displayName = "Textarea";

--- a/web/src/lib/edits.ts
+++ b/web/src/lib/edits.ts
@@ -1,0 +1,220 @@
+/**
+ * High-level edit/add operations: locate shard → fetch → mutate → PUT.
+ * Triggers update-daily workflow after each commit so markdown stays in sync.
+ */
+import {
+  getContents,
+  putContents,
+  dispatchWorkflow,
+  ConflictError,
+} from "./github-api";
+import {
+  shardForFlatIndex,
+  decodeBase64Utf8,
+  parseShardJsonl,
+  serializeShardJsonl,
+  findRecordIndexByAppid,
+} from "./jsonl-shard";
+import { extractAppid, normalizeLink } from "./data-store";
+import { TEMP_JSONL, DATA_DIR, type DataIndex, type GameRecord } from "./schema";
+
+export interface EditPatch {
+  genre?: string;
+  type_game?: "online" | "offline" | "";
+  anti_cheat?: string;
+  anti_cheat_note?: string;
+  is_kernel_ac?: boolean | null;
+  notes?: string;
+  safe?: "y" | "n" | "?" | "";
+  status?: "active" | "delisted";
+}
+
+export interface UpdateGameInput {
+  record: GameRecord;
+  patch: EditPatch;
+  flatIndex: number;
+  index: DataIndex;
+  token: string;
+  triggerMarkdownRebuild?: boolean;
+}
+
+export interface EditResult {
+  shard: string;
+  commitSha: string;
+  htmlUrl: string;
+}
+
+/** Apply only non-undefined fields from a patch to a record. */
+function applyPatch(record: GameRecord, patch: EditPatch): GameRecord {
+  const out = { ...record };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) continue;
+    (out as unknown as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Update one game record. Locates its shard, fetches latest content + sha,
+ * applies the patch, and PUTs the new content back.
+ *
+ * Throws ConflictError if the shard's sha changed between fetch and PUT.
+ */
+export async function updateGame(input: UpdateGameInput): Promise<EditResult> {
+  const appid = extractAppid(input.record.link);
+  if (!appid) throw new Error("Record has no appid");
+
+  const shard = shardForFlatIndex(input.flatIndex, input.index);
+  const shardPath = `${DATA_DIR}/${shard}`;
+
+  // 1. Fetch current shard
+  const current = await getContents(shardPath, input.token);
+  if (!current) throw new Error(`Shard not found: ${shardPath}`);
+
+  // 2. Parse + locate
+  const text = decodeBase64Utf8(current.content);
+  const records = parseShardJsonl(text);
+  const idx = findRecordIndexByAppid(records, appid);
+  if (idx === -1) {
+    throw new Error(
+      `Record ${appid} not found in ${shard}. The shard may have been re-balanced.`,
+    );
+  }
+
+  // 3. Apply patch
+  records[idx] = applyPatch(records[idx], input.patch);
+  const newText = serializeShardJsonl(records);
+
+  // 4. PUT
+  const result = await putContents({
+    pathInRepo: shardPath,
+    content: newText,
+    message: `Edit ${input.record.name || appid} (${shard})`,
+    sha: current.sha,
+    token: input.token,
+  });
+
+  // 5. Optionally trigger markdown rebuild
+  if (input.triggerMarkdownRebuild) {
+    try {
+      await dispatchWorkflow("update-daily.yml", input.token);
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  return { shard, commitSha: result.commitSha, htmlUrl: result.htmlUrl };
+}
+
+/** Re-runs updateGame once on conflict (for transient races with the daily pipeline). */
+export async function updateGameWithRetry(
+  input: UpdateGameInput,
+): Promise<EditResult> {
+  try {
+    return await updateGame(input);
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      // 1 retry — caller refetches data and re-applies if this also fails
+      return await updateGame(input);
+    }
+    throw err;
+  }
+}
+
+/* ──────────── Add (queue to temp_info.jsonl) ──────────── */
+
+export interface AddLinksResult {
+  added: string[];
+  skipped: { link: string; reason: string }[];
+  commitSha: string;
+}
+
+/**
+ * Append links to scripts/temp_info.jsonl. Triggers the existing ingest-new
+ * workflow which will fetch full Steam metadata.
+ *
+ * @param links — raw input lines (URLs or bare appids)
+ * @param existingAppids — set of appids already in the dataset (for dedup)
+ */
+export async function addLinks(
+  links: string[],
+  existingAppids: Set<string>,
+  token: string,
+): Promise<AddLinksResult> {
+  const added: string[] = [];
+  const skipped: { link: string; reason: string }[] = [];
+  const seenInBatch = new Set<string>();
+
+  for (const raw of links) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const normalized = normalizeLink(trimmed);
+    if (!normalized) {
+      skipped.push({ link: trimmed, reason: "not a valid Steam link" });
+      continue;
+    }
+    const appid = extractAppid(normalized);
+    if (!appid) {
+      skipped.push({ link: trimmed, reason: "no appid" });
+      continue;
+    }
+    if (existingAppids.has(appid)) {
+      skipped.push({ link: trimmed, reason: "already in dataset" });
+      continue;
+    }
+    if (seenInBatch.has(appid)) {
+      skipped.push({ link: trimmed, reason: "duplicate in this batch" });
+      continue;
+    }
+    seenInBatch.add(appid);
+    added.push(normalized);
+  }
+
+  if (added.length === 0) {
+    throw new Error("No new links to add. " + skipped.map((s) => s.reason).join(", "));
+  }
+
+  // Fetch existing temp_info.jsonl (may be empty)
+  const current = await getContents(TEMP_JSONL, token);
+  const existingText = current ? decodeBase64Utf8(current.content) : "";
+  const existingLines = existingText.split("\n").filter((l) => l.trim());
+
+  // Also dedup against existing temp queue
+  const queuedAppids = new Set<string>();
+  for (const line of existingLines) {
+    try {
+      const obj = JSON.parse(line);
+      const aid = extractAppid(obj.link);
+      if (aid) queuedAppids.add(aid);
+    } catch {
+      /* skip */
+    }
+  }
+
+  const trulyNew: string[] = [];
+  for (const link of added) {
+    const aid = extractAppid(link);
+    if (aid && queuedAppids.has(aid)) {
+      skipped.push({ link, reason: "already queued" });
+    } else {
+      trulyNew.push(link);
+    }
+  }
+
+  if (trulyNew.length === 0) {
+    throw new Error("All links are already queued.");
+  }
+
+  const newLines = trulyNew.map((l) => JSON.stringify({ link: l }));
+  const merged = [...existingLines, ...newLines].join("\n") + "\n";
+
+  const result = await putContents({
+    pathInRepo: TEMP_JSONL,
+    content: merged,
+    message: `Queue ${trulyNew.length} game${trulyNew.length === 1 ? "" : "s"} for ingest`,
+    sha: current?.sha,
+    token,
+  });
+
+  return { added: trulyNew, skipped, commitSha: result.commitSha };
+}

--- a/web/src/lib/github-api.ts
+++ b/web/src/lib/github-api.ts
@@ -1,18 +1,19 @@
 /**
- * GitHub Contents API + workflow_dispatch helpers.
- * Used by Phase 2 (edit/add/delete). Stub-safe: read-side works without auth.
+ * GitHub Contents API + workflow_dispatch helpers + auth.
+ * Uses fine-grained or classic PAT stored in localStorage.
+ * Classic PATs auto-sign commits via GitHub web-flow → "Verified" badge.
  */
 import { REPO_OWNER, REPO_NAME, DEFAULT_BRANCH } from "./schema";
 
 const API_BASE = "https://api.github.com";
 
+const TOKEN_KEY = "f2p:gh_token";
+const USER_KEY = "f2p:gh_user";
+
 export interface AuthState {
   token: string | null;
   user: string | null;
 }
-
-const TOKEN_KEY = "f2p:gh_token";
-const USER_KEY = "f2p:gh_user";
 
 export function loadAuth(): AuthState {
   return {
@@ -40,11 +41,48 @@ function authHeaders(token: string | null): HeadersInit {
   return h;
 }
 
+export interface GitHubUser {
+  login: string;
+  avatar_url: string;
+  name: string | null;
+  html_url: string;
+}
+
+export async function fetchUser(token: string): Promise<GitHubUser> {
+  const res = await fetch(`${API_BASE}/user`, { headers: authHeaders(token) });
+  if (!res.ok) {
+    throw new Error(`Token invalid (${res.status}). Check scopes & expiry.`);
+  }
+  return (await res.json()) as GitHubUser;
+}
+
+/**
+ * Sanity check that the token can read+write the target repo.
+ * Returns the user's permission level on the repo.
+ */
+export async function checkRepoAccess(
+  token: string,
+): Promise<{ ok: boolean; permission?: string; error?: string }> {
+  const res = await fetch(
+    `${API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}`,
+    { headers: authHeaders(token) },
+  );
+  if (!res.ok) return { ok: false, error: `${res.status} ${res.statusText}` };
+  const data = await res.json();
+  const perm = data?.permissions;
+  if (!perm) return { ok: false, error: "no permissions field on response" };
+  if (!perm.push) {
+    return { ok: false, error: "Token lacks push permission on this repo" };
+  }
+  return { ok: true, permission: perm.admin ? "admin" : "write" };
+}
+
 export interface ContentsResponse {
   sha: string;
   content: string;
   encoding: "base64";
   path: string;
+  size: number;
 }
 
 export async function getContents(
@@ -68,10 +106,28 @@ export interface PutContentsInput {
   token: string;
 }
 
-export async function putContents(input: PutContentsInput): Promise<void> {
+export interface PutContentsResult {
+  sha: string;
+  commitSha: string;
+  htmlUrl: string;
+}
+
+/**
+ * Encodes UTF-8 string to base64 safely (handles non-ASCII).
+ */
+function utf8ToBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+export async function putContents(
+  input: PutContentsInput,
+): Promise<PutContentsResult> {
   const body = {
     message: input.message,
-    content: btoa(unescape(encodeURIComponent(input.content))),
+    content: utf8ToBase64(input.content),
     branch: DEFAULT_BRANCH,
     sha: input.sha,
   };
@@ -83,9 +139,25 @@ export async function putContents(input: PutContentsInput): Promise<void> {
       body: JSON.stringify(body),
     },
   );
+  if (res.status === 409) {
+    throw new ConflictError(input.pathInRepo);
+  }
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`PUT contents ${input.pathInRepo}: ${res.status} ${text}`);
+  }
+  const data = await res.json();
+  return {
+    sha: data.content.sha,
+    commitSha: data.commit.sha,
+    htmlUrl: data.commit.html_url,
+  };
+}
+
+export class ConflictError extends Error {
+  constructor(public path: string) {
+    super(`Conflict on ${path} — file changed remotely. Refetch and retry.`);
+    this.name = "ConflictError";
   }
 }
 
@@ -102,13 +174,17 @@ export async function dispatchWorkflow(
       body: JSON.stringify({ ref: DEFAULT_BRANCH, inputs: inputs ?? {} }),
     },
   );
-  if (!res.ok) throw new Error(`workflow_dispatch ${workflowFile}: ${res.status}`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`workflow_dispatch ${workflowFile}: ${res.status} ${text}`);
+  }
 }
 
 export interface RateLimit {
   limit: number;
   remaining: number;
   reset: number;
+  used: number;
 }
 
 export async function getRateLimit(token: string | null): Promise<RateLimit | null> {
@@ -120,4 +196,27 @@ export async function getRateLimit(token: string | null): Promise<RateLimit | nu
   } catch {
     return null;
   }
+}
+
+export interface WorkflowRun {
+  id: number;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+  created_at: string;
+  head_sha: string;
+}
+
+export async function getRecentWorkflowRuns(
+  workflowFile: string,
+  token: string | null,
+  limit = 5,
+): Promise<WorkflowRun[]> {
+  const res = await fetch(
+    `${API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/actions/workflows/${workflowFile}/runs?per_page=${limit}`,
+    { headers: authHeaders(token) },
+  );
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.workflow_runs ?? []) as WorkflowRun[];
 }

--- a/web/src/lib/jsonl-shard.ts
+++ b/web/src/lib/jsonl-shard.ts
@@ -1,0 +1,59 @@
+/**
+ * JSONL shard helpers — locate a record's shard, mutate, re-serialize.
+ */
+import { extractAppid } from "./data-store";
+import type { DataIndex, GameRecord } from "./schema";
+
+/** Given a flat record index and the shard manifest, return the shard filename. */
+export function shardForFlatIndex(
+  flatIdx: number,
+  index: DataIndex,
+): string {
+  let cum = 0;
+  for (const f of index.files) {
+    if (flatIdx < cum + f.count) return f.name;
+    cum += f.count;
+  }
+  // Fallback: append to last shard.
+  return index.files[index.files.length - 1]?.name ?? "data_001.jsonl";
+}
+
+/** Decode base64 (UTF-8) shard content from Contents API. */
+export function decodeBase64Utf8(b64: string): string {
+  const cleaned = b64.replace(/\s/g, "");
+  const binary = atob(cleaned);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+/** Parse JSONL text into GameRecord array (no migration; raw shape). */
+export function parseShardJsonl(text: string): GameRecord[] {
+  const out: GameRecord[] = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      out.push(JSON.parse(t));
+    } catch {
+      /* skip bad lines */
+    }
+  }
+  return out;
+}
+
+/** Serialize records → JSONL (one record per line, no trailing newline). */
+export function serializeShardJsonl(records: GameRecord[]): string {
+  return records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+}
+
+/** Find the index of the record matching the given appid. -1 if not found. */
+export function findRecordIndexByAppid(
+  records: GameRecord[],
+  appid: string,
+): number {
+  for (let i = 0; i < records.length; i++) {
+    if (extractAppid(records[i].link) === appid) return i;
+  }
+  return -1;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HashRouter } from "react-router-dom";
+import { Toaster } from "sonner";
 import App from "./App";
 import "./index.css";
 
@@ -21,6 +22,19 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
       <HashRouter>
         <App />
+        <Toaster
+          richColors
+          closeButton
+          theme="dark"
+          position="bottom-right"
+          toastOptions={{
+            style: {
+              background: "hsl(var(--card))",
+              color: "hsl(var(--card-foreground))",
+              border: "1px solid hsl(var(--border))",
+            },
+          }}
+        />
       </HashRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/web/src/pages/Add.tsx
+++ b/web/src/pages/Add.tsx
@@ -1,10 +1,316 @@
-import { PlaceholderPage } from "../components/common/QueryState";
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, PlusCircle, Sparkles, ListPlus, ExternalLink } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { Textarea } from "../components/ui/textarea";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
+import { Label } from "../components/ui/label";
+import { Separator } from "../components/ui/separator";
+import { useAuth } from "../stores/auth";
+import { useGames } from "../hooks/useGames";
+import { addLinks } from "../lib/edits";
+import { extractAppid, normalizeLink } from "../lib/data-store";
+import { LoadingState } from "../components/common/QueryState";
 
 export function AddPage() {
+  const auth = useAuth();
+  const games = useGames();
+  const queryClient = useQueryClient();
+
+  const existingAppids = useMemo(() => {
+    const set = new Set<string>();
+    if (!games.data) return set;
+    for (const aid of games.data.appidIndex.keys()) set.add(aid);
+    return set;
+  }, [games.data]);
+
+  if (games.isLoading) return <LoadingState />;
+  if (!games.data) return null;
+
+  if (!auth.isAuthenticated) {
+    return (
+      <div className="max-w-2xl space-y-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Add games</h1>
+          <p className="text-sm text-muted-foreground">
+            Paste a Steam link → it gets queued for the daily ingest pipeline.
+          </p>
+        </div>
+        <Card>
+          <CardContent className="space-y-2 p-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              Sign in to GitHub to add games. Read-only browse works without sign-in.
+            </p>
+            <Button onClick={() => (window.location.hash = "#/settings")}>
+              Go to Settings
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
-    <PlaceholderPage
-      title="Add games"
-      description="Single + bulk add via Steam links → queues to scripts/temp_info.jsonl. Requires GitHub auth — Phase 2."
-    />
+    <div className="max-w-3xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Add games</h1>
+        <p className="text-sm text-muted-foreground">
+          Paste Steam links — they queue to <code>scripts/temp_info.jsonl</code>. The
+          existing <code>ingest-new.yml</code> workflow fetches full Steam metadata
+          (name, reviews, players, languages, anti-cheat) and merges it into the data
+          shards. Refresh this page in ~3–5 minutes to see new rows.
+        </p>
+      </div>
+
+      <SingleAdd
+        existingAppids={existingAppids}
+        token={auth.token!}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ["games"] })}
+      />
+
+      <BulkAdd
+        existingAppids={existingAppids}
+        token={auth.token!}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ["games"] })}
+      />
+    </div>
+  );
+}
+
+interface SubProps {
+  existingAppids: Set<string>;
+  token: string;
+  onSuccess: () => void;
+}
+
+function SingleAdd({ existingAppids, token, onSuccess }: SubProps) {
+  const [link, setLink] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const normalized = link.trim() ? normalizeLink(link.trim()) : null;
+  const appid = normalized ? extractAppid(normalized) : null;
+  const dup = appid ? existingAppids.has(appid) : false;
+  const valid = !!normalized && !dup;
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!normalized) return;
+    setBusy(true);
+    try {
+      const result = await addLinks([normalized], existingAppids, token);
+      toast.success(`Queued ${result.added.length} game`, {
+        description: `Commit ${result.commitSha.slice(0, 7)} — ingest workflow starting`,
+      });
+      setLink("");
+      onSuccess();
+    } catch (err) {
+      toast.error("Add failed", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <PlusCircle className="h-4 w-4" /> Single add
+        </CardTitle>
+        <CardDescription>Paste a Steam URL or appid.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={submit} className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="link">Steam link or appid</Label>
+            <Input
+              id="link"
+              placeholder="https://store.steampowered.com/app/730/  or just  730"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+              disabled={busy}
+            />
+          </div>
+
+          {link.trim() && (
+            <div className="rounded-md border bg-muted/30 p-3 text-xs">
+              {normalized ? (
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-muted-foreground">{normalized}</span>
+                  {dup ? (
+                    <Badge variant="warning">already in dataset</Badge>
+                  ) : (
+                    <Badge variant="success">new · appid {appid}</Badge>
+                  )}
+                </div>
+              ) : (
+                <span className="text-destructive">Not a valid Steam link.</span>
+              )}
+            </div>
+          )}
+
+          <Button type="submit" disabled={!valid || busy}>
+            {busy ? (
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            ) : (
+              <Sparkles className="mr-1 h-3 w-3" />
+            )}
+            {busy ? "Queueing…" : "Queue for ingest"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BulkAdd({ existingAppids, token, onSuccess }: SubProps) {
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const preview = useMemo(() => {
+    const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+    const valid: string[] = [];
+    const dup: string[] = [];
+    const bad: string[] = [];
+    const seen = new Set<string>();
+    for (const line of lines) {
+      const norm = normalizeLink(line);
+      if (!norm) {
+        bad.push(line);
+        continue;
+      }
+      const aid = extractAppid(norm);
+      if (!aid) {
+        bad.push(line);
+        continue;
+      }
+      if (existingAppids.has(aid)) {
+        dup.push(aid);
+        continue;
+      }
+      if (seen.has(aid)) continue;
+      seen.add(aid);
+      valid.push(norm);
+    }
+    return { valid, dup, bad };
+  }, [text, existingAppids]);
+
+  async function submit() {
+    if (preview.valid.length === 0) return;
+    setBusy(true);
+    try {
+      const result = await addLinks(preview.valid, existingAppids, token);
+      toast.success(`Queued ${result.added.length} games`, {
+        description: `Commit ${result.commitSha.slice(0, 7)} — ingest workflow starting`,
+        action: {
+          label: "View runs",
+          onClick: () =>
+            window.open(
+              "https://github.com/poli0981/free-steam-games-list/actions/workflows/ingest-new.yml",
+              "_blank",
+            ),
+        },
+      });
+      setText("");
+      onSuccess();
+    } catch (err) {
+      toast.error("Bulk add failed", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ListPlus className="h-4 w-4" /> Bulk add
+        </CardTitle>
+        <CardDescription>
+          One Steam URL or appid per line. Duplicates and invalid lines are skipped.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Textarea
+          placeholder={`730\nhttps://store.steampowered.com/app/570/\n440`}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          disabled={busy}
+          rows={8}
+          className="font-mono text-xs"
+        />
+
+        {text.trim() && (
+          <>
+            <Separator />
+            <div className="grid grid-cols-3 gap-3 text-sm">
+              <Stat label="Valid new" value={preview.valid.length} variant="success" />
+              <Stat label="Already in dataset" value={preview.dup.length} variant="warning" />
+              <Stat label="Invalid" value={preview.bad.length} variant="destructive" />
+            </div>
+
+            {preview.bad.length > 0 && (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-2 text-xs">
+                <div className="mb-1 font-semibold">Invalid lines (skipped):</div>
+                <ul className="space-y-0.5 font-mono text-destructive/90">
+                  {preview.bad.slice(0, 5).map((b, i) => (
+                    <li key={i} className="truncate">
+                      {b}
+                    </li>
+                  ))}
+                  {preview.bad.length > 5 && (
+                    <li>+{preview.bad.length - 5} more…</li>
+                  )}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button onClick={submit} disabled={preview.valid.length === 0 || busy}>
+            {busy ? (
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            ) : (
+              <Sparkles className="mr-1 h-3 w-3" />
+            )}
+            {busy
+              ? "Queueing…"
+              : `Queue ${preview.valid.length} game${preview.valid.length === 1 ? "" : "s"}`}
+          </Button>
+          <a
+            href="https://github.com/poli0981/free-steam-games-list/actions/workflows/ingest-new.yml"
+            target="_blank"
+            rel="noreferrer"
+            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            View ingest runs <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  variant,
+}: {
+  label: string;
+  value: number;
+  variant: "success" | "warning" | "destructive";
+}) {
+  return (
+    <div className="rounded-md border bg-card p-3">
+      <Badge variant={variant}>{label}</Badge>
+      <div className="mt-1 text-2xl font-semibold">{value}</div>
+    </div>
   );
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,10 +1,70 @@
-import { PlaceholderPage } from "../components/common/QueryState";
+import { useEffect, useState } from "react";
+import { AuthPanel } from "../components/auth/AuthPanel";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { useAuth } from "../stores/auth";
+import { getRateLimit, type RateLimit } from "../lib/github-api";
+import { formatNumber } from "../lib/utils";
 
 export function SettingsPage() {
+  const auth = useAuth();
+  const [rate, setRate] = useState<RateLimit | null>(null);
+
+  useEffect(() => {
+    if (!auth.isAuthenticated) {
+      setRate(null);
+      return;
+    }
+    let cancelled = false;
+    getRateLimit(auth.token).then((r) => {
+      if (!cancelled) setRate(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.isAuthenticated, auth.token]);
+
   return (
-    <PlaceholderPage
-      title="Settings"
-      description="GitHub OAuth Device Flow, theme, language, keyboard shortcuts — Phase 2."
-    />
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Authentication, theme, and preferences.
+        </p>
+      </div>
+
+      <AuthPanel />
+
+      {auth.isAuthenticated && rate && (
+        <Card>
+          <CardHeader>
+            <CardTitle>API rate limit</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-4 text-sm">
+              <div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Remaining
+                </div>
+                <div className="text-xl font-semibold">{formatNumber(rate.remaining)}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Limit
+                </div>
+                <div className="text-xl font-semibold">{formatNumber(rate.limit)}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Resets
+                </div>
+                <div className="text-xl font-semibold">
+                  {new Date(rate.reset * 1000).toLocaleTimeString()}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
   );
 }

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,0 +1,92 @@
+import { create } from "zustand";
+import {
+  loadAuth,
+  saveAuth,
+  clearAuth,
+  fetchUser,
+  checkRepoAccess,
+  type GitHubUser,
+} from "../lib/github-api";
+
+interface AuthStore {
+  token: string | null;
+  user: GitHubUser | null;
+  isAuthenticated: boolean;
+  isVerifying: boolean;
+  error: string | null;
+  permission: string | null;
+
+  hydrate: () => Promise<void>;
+  signIn: (token: string) => Promise<void>;
+  signOut: () => void;
+}
+
+const persisted = loadAuth();
+
+export const useAuth = create<AuthStore>((set, get) => ({
+  token: persisted.token,
+  user: null,
+  isAuthenticated: !!persisted.token,
+  isVerifying: false,
+  error: null,
+  permission: null,
+
+  hydrate: async () => {
+    const token = get().token;
+    if (!token) return;
+    set({ isVerifying: true, error: null });
+    try {
+      const [user, repo] = await Promise.all([
+        fetchUser(token),
+        checkRepoAccess(token),
+      ]);
+      if (!repo.ok) throw new Error(repo.error ?? "no repo access");
+      set({
+        user,
+        permission: repo.permission ?? "write",
+        isAuthenticated: true,
+        isVerifying: false,
+      });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        isVerifying: false,
+        isAuthenticated: false,
+        token: null,
+        user: null,
+      });
+      clearAuth();
+    }
+  },
+
+  signIn: async (token: string) => {
+    set({ isVerifying: true, error: null });
+    try {
+      const [user, repo] = await Promise.all([
+        fetchUser(token),
+        checkRepoAccess(token),
+      ]);
+      if (!repo.ok) throw new Error(repo.error ?? "no repo access");
+      saveAuth(token, user.login);
+      set({
+        token,
+        user,
+        permission: repo.permission ?? "write",
+        isAuthenticated: true,
+        isVerifying: false,
+      });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : String(err),
+        isVerifying: false,
+        isAuthenticated: false,
+      });
+      throw err;
+    }
+  },
+
+  signOut: () => {
+    clearAuth();
+    set({ token: null, user: null, isAuthenticated: false, error: null, permission: null });
+  },
+}));


### PR DESCRIPTION
## Summary

Phase 2 brings write capabilities to the web app: **PAT-based GitHub auth**, **single-record edit** of the 8 manual fields with diff preview, and **single + bulk Steam-link add** that queues into ``scripts/temp_info.jsonl`` (the existing ``ingest-new.yml`` workflow handles the metadata fetch).

- **Bundle delta:** ~17 KB gzipped (62 KB index chunk vs 45 KB in Phase 1) — auth, edit drawer, add forms, sonner toasts.
- **Build:** ``npx tsc --noEmit`` passes; ``npx vite build`` ~3.6 s.

## What's new

| Area | Files | Notes |
|---|---|---|
| Auth | ``web/src/stores/auth.ts``, ``web/src/components/auth/AuthPanel.tsx`` | Zustand store, Classic PAT path. Fetches ``/user`` + repo permission check. Token in localStorage. |
| Edit | ``web/src/components/games/EditGameDrawer.tsx``, ``web/src/components/games/DiffViewer.tsx``, ``web/src/lib/edits.ts``, ``web/src/lib/jsonl-shard.ts`` | Drawer for 8 manual fields. Locates shard via ``shardForFlatIndex``, GETs sha, mutates in place, PUTs back, then dispatches ``update-daily.yml`` for markdown rebuild. 1 retry on 409 conflict. |
| Add | ``web/src/pages/Add.tsx`` | Single + bulk forms, dedup vs in-memory ``appidIndex`` and already-queued ``temp_info.jsonl``. |
| UX | ``sonner`` toaster, Topbar avatar + Verified badge, Settings page rate-limit display | |
| Schema | ``web/src/lib/schema.ts`` exports ``TEMP_JSONL`` constant | |

## Auth design choice

Plan said OAuth Device Flow. Implementation uses **PAT** because Device Flow needs a registered GitHub OAuth App (CLIENT_ID) — adding that ceremony delays Phase 2 with no functional gain for a single-user tool. **Classic PATs still get GitHub-signed "Verified" commits** because GitHub web-flow signs server-side. Fine-grained PATs work too (no Verified badge). Device Flow can land in Phase 3 once an OAuth App is registered.

## Test plan

- [x] ``npx tsc --noEmit`` strict mode passes
- [x] ``npx vite build`` produces working ``dist/``
- [ ] Sign in with a Classic PAT (scopes: ``repo`` + ``workflow``) → avatar appears in topbar
- [ ] Edit a game's ``notes`` field → diff preview shows the change → commit → "Verified" commit appears on main → row updates after refetch
- [ ] Edit conflict path: edit while ``update-json`` is running → 409 should retry once, then surface conflict toast on second failure
- [ ] Add single Steam link (e.g. ``730``) when not in dataset → queued → ``ingest-new.yml`` runs → row appears in ~3-5 min
- [ ] Bulk add 5 links with mix of valid/dup/invalid → preview shows correct counts → commit → ingest run picks up
- [ ] Sign out clears token from localStorage

## Roadmap

- **Phase 3:** Bulk edit/delete, 8 remaining charts (heatmap, word cloud, stacked AC, histograms), PWA, i18n vi/en, command palette, activity feed, optional Tauri desktop wrap, optional OAuth Device Flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)