### PR TITLE
Fix GPG signature: drop trailing newline after commit message

### DIFF
--- a/web/src/lib/git-data.ts
+++ b/web/src/lib/git-data.ts
@@ -158,7 +158,8 @@ export interface CommitResult {
 
 /**
  * Build the exact bytes of a Git commit object so OpenPGP.js can sign them.
- * GitHub recomputes this server-side; if our bytes diverge, signature fails.
+ * GitHub recomputes this server-side; if our bytes diverge, signature fails
+ * with verification.reason="invalid".
  *
  * Format (each \n is literal):
  *   tree HEX\n
@@ -166,7 +167,13 @@ export interface CommitResult {
  *   author NAME <EMAIL> UNIX_TS +0000\n
  *   committer NAME <EMAIL> UNIX_TS +0000\n
  *   \n
- *   MESSAGE\n
+ *   MESSAGE              ← NO trailing newline
+ *
+ * Empirical: GitHub's verification.payload (the bytes it actually verifies
+ * the signature against) does NOT include a trailing \n after the message.
+ * Earlier we appended one and the signature came back as `reason: "invalid"`
+ * because the bytes were 1 byte longer than GitHub's. See
+ * GET /repos/{o}/{r}/commits/{sha}.commit.verification.payload to inspect.
  */
 export function buildCommitContent(input: CreateCommitInput): string {
   const fmt = (id: IdentityInput) =>
@@ -177,7 +184,7 @@ export function buildCommitContent(input: CreateCommitInput): string {
     `author ${fmt(input.author)}\n` +
     `committer ${fmt(input.committer)}\n`;
   const message = input.message.replace(/\n+$/, "");
-  return `${headers}\n${message}\n`;
+  return `${headers}\n${message}`;
 }
 
 export async function createCommit(


### PR DESCRIPTION
## Diagnosis

Tested against the two unverified post-Phase-4 signed commits:

\`\`\`
$ gh api repos/poli0981/free-steam-games-list/commits/8586ce99 -q '.commit.verification.reason'
invalid
\`\`\`

\`reason: "invalid"\` means GitHub found the GPG key but the cryptographic check failed — i.e., the bytes we signed don't equal the bytes GitHub recomputes server-side. So this isn't an email/username problem; the email is already correctly mirrored across author + committer + GPG key user ID.

The smoking gun is in \`verification.payload\` — the exact byte string GitHub fed to its verifier:

\`\`\`
$ python3 -c "import json,sys; p=json.load(sys.stdin)['commit']['verification']['payload']; print(len(p), repr(p[-5:]), p.endswith('\n'))" < commit.json
287 'ngest' False
\`\`\`

GitHub's payload is **287 bytes and does NOT end with \`\n\`**. Our buildCommitContent appended one, so our signed payload was 288 bytes — 1 byte longer — breaking the signature.

## Fix

Drop the trailing \`\n\` from \`buildCommitContent\` after the message. The function already strips trailing newlines from the input message before concatenation, so the result is now exactly the bytes GitHub uses.

\`\`\`diff
- return \`\${headers}\n\${message}\n\`;
+ return \`\${headers}\n\${message}\`;
\`\`\`

## On adding username/email override fields

Worth doing as a Phase 5 UX nicety — useful for users whose key has multiple userIDs or who want to commit under a different verified email — but **it's not the cause of this bug**. The recent failed commits already have matching name+email throughout (\`anon (hello) <127664709+poli0981@users.noreply.github.com>\`). I'd defer that to its own PR rather than mix it into this hotfix.

## Test plan

- [x] tsc --noEmit clean
- [x] vite build 3.65 s
- [ ] After merge: edit any record's notes via the web app → commit lands → check the commit page on GitHub: should now show the green **Verified** badge, and \`gh api .../commits/{sha} -q '.commit.verification.reason'\` should return \`valid\` instead of \`invalid\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)