### PR TITLE
Fix Edit always failing: route reads through Git Data API for files > 1 MB

### DIFF
--- a/web/src/lib/edits.ts
+++ b/web/src/lib/edits.ts
@@ -7,16 +7,16 @@
  *   • After each successful edit commit, dispatches update-daily.yml so the
  *     markdown tables in games/ stay in sync with the data shards.
  */
-import { getContents, dispatchWorkflow } from "./github-api";
+import { dispatchWorkflow } from "./github-api";
 import {
   commitFileWithRetry,
   commitFilesWithRetry,
+  getRepoFileText,
   RefAdvancedError,
   type CommitResult,
 } from "./git-data";
 import {
   shardForFlatIndex,
-  decodeBase64Utf8,
   parseShardJsonl,
   serializeShardJsonl,
   findRecordIndexByAppid,
@@ -80,15 +80,14 @@ export async function updateGame(input: UpdateGameInput): Promise<EditResult> {
   const shard = shardForFlatIndex(input.flatIndex, input.index);
   const shardPath = `${DATA_DIR}/${shard}`;
 
-  const current = await getContents(shardPath, input.token);
+  const current = await getRepoFileText(shardPath, input.token);
   if (!current) throw new Error(`Shard not found: ${shardPath}`);
 
-  const text = decodeBase64Utf8(current.content);
-  const records = parseShardJsonl(text);
+  const records = parseShardJsonl(current.text);
   const idx = findRecordIndexByAppid(records, appid);
   if (idx === -1) {
     throw new Error(
-      `Record ${appid} not found in ${shard} — shard may have been re-balanced.`,
+      `Record ${appid} not found in ${shard} (${records.length} rows in shard) — shard may have been re-balanced.`,
     );
   }
   records[idx] = applyPatch(records[idx], input.patch);
@@ -141,12 +140,15 @@ export async function replaceGame(input: ReplaceGameInput): Promise<EditResult> 
 
   const shard = shardForFlatIndex(input.flatIndex, input.index);
   const shardPath = `${DATA_DIR}/${shard}`;
-  const current = await getContents(shardPath, input.token);
+  const current = await getRepoFileText(shardPath, input.token);
   if (!current) throw new Error(`Shard not found: ${shardPath}`);
 
-  const records = parseShardJsonl(decodeBase64Utf8(current.content));
+  const records = parseShardJsonl(current.text);
   const idx = findRecordIndexByAppid(records, appid);
-  if (idx === -1) throw new Error(`Record ${appid} not in ${shard}`);
+  if (idx === -1)
+    throw new Error(
+      `Record ${appid} not in ${shard} (${records.length} rows in shard)`,
+    );
 
   // Preserve added_at from the original — it's a "creation time" the user
   // shouldn't be able to retroactively rewrite via the JSON editor.
@@ -222,9 +224,9 @@ export async function bulkEditGames(
   await Promise.all(
     Array.from(byShard.entries()).map(async ([shard, appids]) => {
       const path = `${DATA_DIR}/${shard}`;
-      const current = await getContents(path, input.token);
+      const current = await getRepoFileText(path, input.token);
       if (!current) throw new Error(`Shard ${shard} not found`);
-      const records = parseShardJsonl(decodeBase64Utf8(current.content));
+      const records = parseShardJsonl(current.text);
       for (const appid of appids) {
         const idx = findRecordIndexByAppid(records, appid);
         if (idx === -1) continue;
@@ -286,8 +288,8 @@ export async function bulkDeleteGames(
 
   // Refetch the entire `removed_games.jsonl` log so we can append.
   const removedLogPath = "scripts/removed_games.jsonl";
-  const removedLog = await getContents(removedLogPath, input.token);
-  const removedLogText = removedLog ? decodeBase64Utf8(removedLog.content) : "";
+  const removedLog = await getRepoFileText(removedLogPath, input.token);
+  const removedLogText = removedLog?.text ?? "";
 
   // Refetch + filter each affected shard.
   const files: { path: string; content: string }[] = [];
@@ -297,9 +299,9 @@ export async function bulkDeleteGames(
   await Promise.all(
     Array.from(shardsTouched).map(async (shard) => {
       const path = `${DATA_DIR}/${shard}`;
-      const current = await getContents(path, input.token);
+      const current = await getRepoFileText(path, input.token);
       if (!current) return;
-      const records = parseShardJsonl(decodeBase64Utf8(current.content));
+      const records = parseShardJsonl(current.text);
       const kept: GameRecord[] = [];
       for (const r of records) {
         const aid = extractAppid(r.link);
@@ -410,8 +412,8 @@ export async function addLinks(input: AddLinksInput): Promise<AddLinksResult> {
     throw new Error("No new links to add. " + skipped.map((s) => s.reason).join(", "));
   }
 
-  const current = await getContents(TEMP_JSONL, input.token);
-  const existingText = current ? decodeBase64Utf8(current.content) : "";
+  const current = await getRepoFileText(TEMP_JSONL, input.token);
+  const existingText = current?.text ?? "";
   const existingLines = existingText.split("\n").filter((l) => l.trim());
 
   const queuedAppids = new Set<string>();

--- a/web/src/lib/git-data.ts
+++ b/web/src/lib/git-data.ts
@@ -60,17 +60,71 @@ export async function getHead(token: string): Promise<RefHead> {
 /** Fetch a blob's UTF-8 text content by sha. */
 export async function getBlobText(
   sha: string,
-  token: string,
+  token: string | null,
 ): Promise<string> {
-  const blob = await ghJson<{ content: string; encoding: "base64" }>(
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(
     `${API}/repos/${REPO_OWNER}/${REPO_NAME}/git/blobs/${sha}`,
-    { headers: authHeaders(token) },
+    { headers },
   );
+  if (!res.ok) throw new Error(`GET blob ${sha}: ${res.status}`);
+  const blob = (await res.json()) as { content: string; encoding: "base64" };
   const cleaned = blob.content.replace(/\s/g, "");
   const bin = atob(cleaned);
   const bytes = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
   return new TextDecoder("utf-8").decode(bytes);
+}
+
+/**
+ * Fetch a repo file as UTF-8 text, transparently falling back from the
+ * Contents API to the Git blob endpoint for files over GitHub's 1 MB
+ * Contents-API limit.
+ *
+ * The Contents API is one round trip and gives us the file SHA + base64
+ * content for files ≤ 1 MB. For oversize files it returns the SHA but
+ * `encoding: "none"` and an empty `content` — at which point we re-fetch
+ * via `/git/blobs/{sha}` (no size limit).
+ *
+ * Returns the same `{ sha, text }` shape regardless of which path was used.
+ * `sha` is the BLOB sha, suitable for PUT-on-Contents-API conflict checks
+ * if the caller still wants that path.
+ */
+export async function getRepoFileText(
+  pathInRepo: string,
+  token: string | null,
+): Promise<{ text: string; sha: string } | null> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(
+    `${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${pathInRepo}?ref=${DEFAULT_BRANCH}`,
+    { headers },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`GET contents ${pathInRepo}: ${res.status}`);
+  const data = (await res.json()) as {
+    sha: string;
+    content?: string;
+    encoding?: string;
+    size?: number;
+  };
+  if (data.encoding === "base64" && data.content) {
+    const cleaned = data.content.replace(/\s/g, "");
+    const bin = atob(cleaned);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return { text: new TextDecoder("utf-8").decode(bytes), sha: data.sha };
+  }
+  // Oversize file → fetch via blob endpoint. Same blob SHA from Contents API.
+  const text = await getBlobText(data.sha, token);
+  return { text, sha: data.sha };
 }
 
 /** Look up a single file's blob sha within the head tree, returning null if absent. */


### PR DESCRIPTION
## Diagnosis

Reproduced from a fresh API call:

\`\`\`
$ gh api repos/poli0981/free-steam-games-list/contents/data/data_001.jsonl \
    | jq '{size, encoding, content_len: (.content | length)}'
{ size: 1494420, encoding: "none", content_len: 0 }
\`\`\`

**The Contents API caps \`content\` at 1 MB.** Files over the cap return an empty string with \`encoding: "none"\`. Phase 6's updateGame / replaceGame / bulkEditGames / bulkDeleteGames / addLinks all read shards through Contents API, then base64-decoded the empty string, parsed an empty JSONL, and surfaced \`Record X not found in {shard} — shard may have been re-balanced.\` as \"Save failed\" for every Edit against shard 1 (~65% of the catalog).

\`data/data_001.jsonl\` is 1.49 MB — way over. \`data/data_002.jsonl\` is 660 KB and \`scripts/temp_info.jsonl\` is empty between ingests, which is why **Bulk edit (Phase 4)** and **Add (Phase 6)** worked while **single Edit** fell over the moment shard 1 was the target.

The detail this could have surfaced sooner — \"empty shard\" — was masked because we just compared \`-1\` and threw the canned \"shard may have been re-balanced\" message.

## Fix

New \`getRepoFileText(path, token)\` in \`lib/git-data.ts\`:

- Tries Contents API first — one round trip, fine for ≤ 1 MB files.
- On \`encoding: \"none\"\` (or any non-base64 response) it re-fetches via \`/git/blobs/{sha}\` — no size limit.
- Returns the same \`{ text, sha }\` shape regardless.

All five write paths in \`edits.ts\` (single edit, JSON-mode replace, bulk edit, bulk delete, add) now route through \`getRepoFileText\`. \`getContents\` + \`decodeBase64Utf8\` are no longer used by edits.ts.

I also tightened the \"record not found\" error to include the parsed shard row count, so an empty-shard regression next time would say \"0 rows in shard\" and pinpoint the read-side immediately.

## Test plan

- [x] tsc --noEmit clean
- [x] vite build 3.82 s
- [ ] Edit any record in shard 1 (e.g. CS2, appid 730) → Save lands. Toast flips through verifying… → Verified ✓ (or unsigned, if GPG locked).
- [ ] Edit any record in shard 2 → still works (was working pre-fix).
- [ ] Bulk edit across both shards → single signed commit lands.
- [ ] Bulk delete → both \`data_*.jsonl\` and \`removed_games.jsonl\` updated atomically.
- [ ] Add — should still work; same code path now uses getRepoFileText for \`temp_info.jsonl\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)