### PR TITLE
Fix stale data after edit: bump index.json + switch SW to NetworkFirst

### DIFF
--- a/web/src/lib/edits.ts
+++ b/web/src/lib/edits.ts
@@ -24,6 +24,47 @@ import {
 import { extractAppid, normalizeLink } from "./data-store";
 import { TEMP_JSONL, DATA_DIR, type DataIndex, type GameRecord } from "./schema";
 
+const INDEX_PATH = `${DATA_DIR}/index.json`;
+
+function nowIsoSeconds(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Read the current data/index.json, bump its last_updated, and return the
+ * file entry to include in a commit. Optional deltas adjust total + per-shard
+ * counts (used for bulk delete). Other fields stay as the pipeline left them.
+ *
+ * Why this matters:
+ *   useGames keys its IndexedDB cache on `last_updated`. If we commit a shard
+ *   without bumping it, every browser tab on the site will keep serving the
+ *   pre-edit cached records on next reload — even when the SW serves a fresh
+ *   shard fetch — because isCacheFresh() returns true. Bumping the manifest
+ *   is the canonical signal that "data changed".
+ */
+async function bumpedIndexFile(
+  token: string | null,
+  deltas: { totalDelta?: number; shardCountDeltas?: Record<string, number> } = {},
+): Promise<{ path: string; content: string }> {
+  const cur = await getRepoFileText(INDEX_PATH, token);
+  if (!cur) throw new Error(`${INDEX_PATH} not found`);
+  const obj = JSON.parse(cur.text) as DataIndex & {
+    max_per_file?: number;
+  };
+  const newTotal = (obj.total ?? 0) + (deltas.totalDelta ?? 0);
+  const newFiles = (obj.files ?? []).map((f) => ({
+    name: f.name,
+    count: f.count + (deltas.shardCountDeltas?.[f.name] ?? 0),
+  }));
+  const next = {
+    max_per_file: obj.max_per_file ?? 800,
+    total: newTotal,
+    last_updated: nowIsoSeconds(),
+    files: newFiles,
+  };
+  return { path: INDEX_PATH, content: JSON.stringify(next, null, 2) + "\n" };
+}
+
 export type CommitSigner = (commitContent: string) => Promise<string>;
 
 export interface CommitAuthor {
@@ -93,9 +134,9 @@ export async function updateGame(input: UpdateGameInput): Promise<EditResult> {
   records[idx] = applyPatch(records[idx], input.patch);
   const newText = serializeShardJsonl(records);
 
-  const commit = await commitFileWithRetry({
-    path: shardPath,
-    content: newText,
+  const indexFile = await bumpedIndexFile(input.token);
+  const commit = await commitFilesWithRetry({
+    files: [{ path: shardPath, content: newText }, indexFile],
     message: `Edit ${input.record.name || appid} (${shard})`,
     author: input.author,
     signer: input.signer,
@@ -157,9 +198,12 @@ export async function replaceGame(input: ReplaceGameInput): Promise<EditResult> 
     added_at: input.original.added_at || input.replacement.added_at,
   };
 
-  const commit = await commitFileWithRetry({
-    path: shardPath,
-    content: serializeShardJsonl(records),
+  const indexFile = await bumpedIndexFile(input.token);
+  const commit = await commitFilesWithRetry({
+    files: [
+      { path: shardPath, content: serializeShardJsonl(records) },
+      indexFile,
+    ],
     message: `Replace ${input.replacement.name || appid} (${shard}) — full JSON edit`,
     author: input.author,
     signer: input.signer,
@@ -237,6 +281,9 @@ export async function bulkEditGames(
     }),
   );
 
+  // Always bump index.json so cache consumers know data changed.
+  files.push(await bumpedIndexFile(input.token));
+
   // 3. One signed commit covers all touched shards.
   const commit = await commitFilesWithRetry({
     files,
@@ -295,6 +342,7 @@ export async function bulkDeleteGames(
   const files: { path: string; content: string }[] = [];
   let removed = 0;
   const removedRecords: GameRecord[] = [];
+  const shardCountDeltas: Record<string, number> = {};
 
   await Promise.all(
     Array.from(shardsTouched).map(async (shard) => {
@@ -303,15 +351,18 @@ export async function bulkDeleteGames(
       if (!current) return;
       const records = parseShardJsonl(current.text);
       const kept: GameRecord[] = [];
+      let removedHere = 0;
       for (const r of records) {
         const aid = extractAppid(r.link);
         if (aid && targetSet.has(aid)) {
           removed++;
+          removedHere++;
           removedRecords.push(r);
         } else {
           kept.push(r);
         }
       }
+      shardCountDeltas[shard] = -removedHere;
       files.push({ path, content: serializeShardJsonl(kept) });
     }),
   );
@@ -323,6 +374,14 @@ export async function bulkDeleteGames(
       ? removedLogText
       : removedLogText + "\n") + newLogLines.join("\n") + "\n";
   files.push({ path: removedLogPath, content: mergedLog });
+
+  // Bump index.json with corrected total + per-shard counts.
+  files.push(
+    await bumpedIndexFile(input.token, {
+      totalDelta: -removed,
+      shardCountDeltas,
+    }),
+  );
 
   const commit = await commitFilesWithRetry({
     files,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -45,14 +45,23 @@ export default defineConfig(({ command }) => ({
         globPatterns: ["**/*.{js,css,html,svg,woff2}"],
         navigateFallback: command === "build" ? `/${repoName}/index.html` : "/index.html",
         runtimeCaching: [
-          // Raw shard data — stale-while-revalidate so offline users see the
-          // last-known catalog and online users get fresh data shortly after.
+          // Raw shard data — NetworkFirst so an edit lands on disk → next page
+          // load fetches the fresh shard, with cache fallback when offline.
+          // Old StaleWhileRevalidate strategy made edits appear only after TWO
+          // reloads (cached on first, refreshed in background, returned on
+          // second). Using NetworkFirst with a short timeout keeps offline UX
+          // intact while making edits visible on the next reload.
+          //
+          // The cache name is bumped to `f2p-data-v2` so users with a stale
+          // SW automatically discard the old entries on activation rather
+          // than serving them from the legacy `f2p-data` cache.
           {
             urlPattern:
               /^https:\/\/raw\.githubusercontent\.com\/poli0981\/free-steam-games-list\/main\/data\/.*/,
-            handler: "StaleWhileRevalidate",
+            handler: "NetworkFirst",
             options: {
-              cacheName: "f2p-data",
+              cacheName: "f2p-data-v2",
+              networkTimeoutSeconds: 5,
               expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 7 },
               cacheableResponse: { statuses: [0, 200] },
             },


### PR DESCRIPTION
## Diagnosis

Two cache layers were hiding successful edits from the UI:

### 1. \`data/index.json.last_updated\` never moved on edits

[\`useGames.ts\`](web/src/hooks/useGames.ts) keeps an IndexedDB cache keyed on \`index.last_updated\`:

\`\`\`ts
if (cached && isCacheFresh(cached.index, index)) {
  return { index: cached.index, records: cached.records, ... };
}
\`\`\`

Phase 6's commit paths (single edit / bulk edit / bulk delete / JSON replace) rewrote the shard but left \`index.json\` alone, so \`isCacheFresh()\` returned \`true\` on the next reload — and the app served the **pre-edit** records straight from IndexedDB, even when the network had the fresh shard.

### 2. Service Worker SWR served the stale shard first anyway

\`vite-plugin-pwa\` runtime cache was \`StaleWhileRevalidate\` for \`raw.githubusercontent.com/.../data/*\`. The strategy returns the cached copy synchronously and refreshes in background:

| Reload | What the user sees |
|---|---|
| \#1 after edit | Stale shard from cache; fresh one downloaded in BG |
| \#2 | Fresh shard finally |

So even with the index.json fix alone, users would still need a second reload before seeing their edit.

## Fix

**Bump \`index.json\` in every data-modifying commit.** New \`bumpedIndexFile()\` helper in \`edits.ts\` reads the current manifest, bumps \`last_updated\`, optionally adjusts \`total\` + per-shard counts (for bulk delete), and is included as a second/Nth file in the same atomic commit as the shard write. \`updateGame\`, \`replaceGame\`, \`bulkEditGames\`, \`bulkDeleteGames\` all route through \`commitFilesWithRetry\` now. \`addLinks\` is unchanged because it doesn't touch \`data/\` — the ingest pipeline bumps \`index.json\` on its own after fetch.

**Switch the SW data cache to \`NetworkFirst\`** with \`networkTimeoutSeconds: 5\`. Online users always get the fresh shard with a 5-second timeout; offline users still fall back to cache. Cache name bumped to \`f2p-data-v2\` so old clients drop the legacy cache on SW activation.

## Test plan

- [x] tsc --noEmit clean
- [x] vite build 4.99 s
- [ ] After merge: edit any record on shard 1 → save → wait for verifying… → Verified ✓ → reload site **once** → row reflects the edit immediately. (Previously: still stale, even after several reloads.)
- [ ] Bulk delete two records spanning both shards → \`index.json.total\` drops by 2 and per-shard \`count\` drops accordingly → reload → table missing those rows.
- [ ] Open DevTools → Application → IndexedDB → \`f2p:index\` shows the bumped \`last_updated\` after refetch.
- [ ] Offline: airplane mode → reload → app shell + last-known data load (NetworkFirst falls back to cache after 5 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)