### PR TITLE
Fix stale-after-edit: optimistically patch local caches, skip CDN bounce

### DIFF
--- a/web/src/components/games/BulkActionBar.tsx
+++ b/web/src/components/games/BulkActionBar.tsx
@@ -18,6 +18,7 @@ import { useAuth } from "../../stores/auth";
 import { useCommitContext } from "../../hooks/useCommitContext";
 import { useIsOwner } from "../../hooks/useIsOwner";
 import { bulkDeleteGames } from "../../lib/edits";
+import { optimisticBulkDelete } from "../../lib/optimistic";
 import { pollCommitVerification } from "../../lib/verify-commit";
 import { BulkEditDrawer } from "./BulkEditDrawer";
 
@@ -103,8 +104,10 @@ export function BulkActionBar({ visibleAppids }: Props) {
           });
         });
       }
+      // Patch local cache instead of invalidating; raw.github CDN is stale
+      // for ~5 min after our commit. See lib/optimistic.ts.
+      optimisticBulkDelete(qc, Array.from(selected));
       clearSelection();
-      await qc.invalidateQueries({ queryKey: ["games"] });
     } catch (err) {
       toast.error("Bulk delete failed", {
         id: toastId,

--- a/web/src/components/games/BulkEditDrawer.tsx
+++ b/web/src/components/games/BulkEditDrawer.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "../../stores/auth";
 import { useGames } from "../../hooks/useGames";
 import { useCommitContext } from "../../hooks/useCommitContext";
 import { bulkEditGames, type EditPatch } from "../../lib/edits";
+import { optimisticBulkEdit } from "../../lib/optimistic";
 import { pollCommitVerification } from "../../lib/verify-commit";
 import {
   ANTI_CHEAT_ENUM,
@@ -157,7 +158,9 @@ export function BulkEditDrawer({ appids, onClose, onCommitted }: Props) {
           });
         });
       }
-      await qc.invalidateQueries({ queryKey: ["games"] });
+      // Patch local cache instead of invalidating — see lib/optimistic.ts
+      // for the CDN-cache rationale.
+      optimisticBulkEdit(qc, appids, patch);
       onCommitted();
     } catch (err) {
       toast.error("Bulk edit failed", {

--- a/web/src/components/games/EditGameDrawer.tsx
+++ b/web/src/components/games/EditGameDrawer.tsx
@@ -34,6 +34,7 @@ import {
   RefAdvancedError,
   type EditPatch,
 } from "../../lib/edits";
+import { optimisticEdit, optimisticReplace } from "../../lib/optimistic";
 import { pollCommitVerification } from "../../lib/verify-commit";
 import {
   ANTI_CHEAT_ENUM,
@@ -202,6 +203,12 @@ export function EditGameDrawer({ game, onClose }: Props) {
     setSaving(true);
     const toastId = `commit-${Date.now()}`;
     try {
+      let replacementRecord: GameRecord | null = null;
+      if (view === "json") {
+        replacementRecord = validateJson(json);
+        if (!replacementRecord) throw new Error(jsonError ?? "Invalid JSON");
+      }
+
       const result =
         view === "form"
           ? await updateGame({
@@ -214,20 +221,30 @@ export function EditGameDrawer({ game, onClose }: Props) {
               token: auth.token,
               triggerMarkdownRebuild: true,
             })
-          : await (async () => {
-              const rep = validateJson(json);
-              if (!rep) throw new Error(jsonError ?? "Invalid JSON");
-              return replaceGame({
-                original: game,
-                replacement: rep,
-                flatIndex,
-                index: games.data!.index,
-                author: ctx.author,
-                signer: ctx.signer,
-                token: auth.token!,
-                triggerMarkdownRebuild: true,
-              });
-            })();
+          : await replaceGame({
+              original: game,
+              replacement: replacementRecord!,
+              flatIndex,
+              index: games.data.index,
+              author: ctx.author,
+              signer: ctx.signer,
+              token: auth.token,
+              triggerMarkdownRebuild: true,
+            });
+
+      // Patch the local cache directly — raw.githubusercontent.com is
+      // Fastly-cached for up to 5 minutes, so a refetch right now would
+      // most likely return the pre-edit shard. We already have the new
+      // data in hand, so write it straight to TanStack + IndexedDB.
+      if (view === "form") {
+        optimisticEdit(qc, flatIndex, patch);
+      } else if (replacementRecord) {
+        optimisticReplace(qc, flatIndex, {
+          ...replacementRecord,
+          // Preserve added_at to match what we wrote on disk.
+          added_at: game.added_at || replacementRecord.added_at,
+        });
+      }
 
       const { commit, shard } = result;
       const sevenSha = commit.sha.slice(0, 7);
@@ -256,7 +273,6 @@ export function EditGameDrawer({ game, onClose }: Props) {
         });
       }
 
-      await qc.invalidateQueries({ queryKey: ["games"] });
       onClose();
     } catch (err) {
       if (err instanceof RefAdvancedError) {
@@ -264,6 +280,7 @@ export function EditGameDrawer({ game, onClose }: Props) {
           id: toastId,
           description: "The daily pipeline committed while you were editing.",
         });
+        // Real refetch is fine here — we lost the race and need fresh state.
         await qc.invalidateQueries({ queryKey: ["games"] });
         onClose();
       } else {

--- a/web/src/lib/edits.ts
+++ b/web/src/lib/edits.ts
@@ -24,6 +24,47 @@ import {
 import { extractAppid, normalizeLink } from "./data-store";
 import { TEMP_JSONL, DATA_DIR, type DataIndex, type GameRecord } from "./schema";
 
+const INDEX_PATH = `${DATA_DIR}/index.json`;
+
+function nowIsoSeconds(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Read the current data/index.json, bump its last_updated, and return the
+ * file entry to include in a commit. Optional deltas adjust total + per-shard
+ * counts (used for bulk delete). Other fields stay as the pipeline left them.
+ *
+ * Why this matters:
+ *   useGames keys its IndexedDB cache on `last_updated`. If we commit a shard
+ *   without bumping it, every browser tab on the site will keep serving the
+ *   pre-edit cached records on next reload — even when the SW serves a fresh
+ *   shard fetch — because isCacheFresh() returns true. Bumping the manifest
+ *   is the canonical signal that "data changed".
+ */
+async function bumpedIndexFile(
+  token: string | null,
+  deltas: { totalDelta?: number; shardCountDeltas?: Record<string, number> } = {},
+): Promise<{ path: string; content: string }> {
+  const cur = await getRepoFileText(INDEX_PATH, token);
+  if (!cur) throw new Error(`${INDEX_PATH} not found`);
+  const obj = JSON.parse(cur.text) as DataIndex & {
+    max_per_file?: number;
+  };
+  const newTotal = (obj.total ?? 0) + (deltas.totalDelta ?? 0);
+  const newFiles = (obj.files ?? []).map((f) => ({
+    name: f.name,
+    count: f.count + (deltas.shardCountDeltas?.[f.name] ?? 0),
+  }));
+  const next = {
+    max_per_file: obj.max_per_file ?? 800,
+    total: newTotal,
+    last_updated: nowIsoSeconds(),
+    files: newFiles,
+  };
+  return { path: INDEX_PATH, content: JSON.stringify(next, null, 2) + "\n" };
+}
+
 export type CommitSigner = (commitContent: string) => Promise<string>;
 
 export interface CommitAuthor {
@@ -93,9 +134,9 @@ export async function updateGame(input: UpdateGameInput): Promise<EditResult> {
   records[idx] = applyPatch(records[idx], input.patch);
   const newText = serializeShardJsonl(records);
 
-  const commit = await commitFileWithRetry({
-    path: shardPath,
-    content: newText,
+  const indexFile = await bumpedIndexFile(input.token);
+  const commit = await commitFilesWithRetry({
+    files: [{ path: shardPath, content: newText }, indexFile],
     message: `Edit ${input.record.name || appid} (${shard})`,
     author: input.author,
     signer: input.signer,
@@ -157,9 +198,12 @@ export async function replaceGame(input: ReplaceGameInput): Promise<EditResult> 
     added_at: input.original.added_at || input.replacement.added_at,
   };
 
-  const commit = await commitFileWithRetry({
-    path: shardPath,
-    content: serializeShardJsonl(records),
+  const indexFile = await bumpedIndexFile(input.token);
+  const commit = await commitFilesWithRetry({
+    files: [
+      { path: shardPath, content: serializeShardJsonl(records) },
+      indexFile,
+    ],
     message: `Replace ${input.replacement.name || appid} (${shard}) — full JSON edit`,
     author: input.author,
     signer: input.signer,
@@ -237,6 +281,9 @@ export async function bulkEditGames(
     }),
   );
 
+  // Always bump index.json so cache consumers know data changed.
+  files.push(await bumpedIndexFile(input.token));
+
   // 3. One signed commit covers all touched shards.
   const commit = await commitFilesWithRetry({
     files,
@@ -295,6 +342,7 @@ export async function bulkDeleteGames(
   const files: { path: string; content: string }[] = [];
   let removed = 0;
   const removedRecords: GameRecord[] = [];
+  const shardCountDeltas: Record<string, number> = {};
 
   await Promise.all(
     Array.from(shardsTouched).map(async (shard) => {
@@ -303,15 +351,18 @@ export async function bulkDeleteGames(
       if (!current) return;
       const records = parseShardJsonl(current.text);
       const kept: GameRecord[] = [];
+      let removedHere = 0;
       for (const r of records) {
         const aid = extractAppid(r.link);
         if (aid && targetSet.has(aid)) {
           removed++;
+          removedHere++;
           removedRecords.push(r);
         } else {
           kept.push(r);
         }
       }
+      shardCountDeltas[shard] = -removedHere;
       files.push({ path, content: serializeShardJsonl(kept) });
     }),
   );
@@ -323,6 +374,14 @@ export async function bulkDeleteGames(
       ? removedLogText
       : removedLogText + "\n") + newLogLines.join("\n") + "\n";
   files.push({ path: removedLogPath, content: mergedLog });
+
+  // Bump index.json with corrected total + per-shard counts.
+  files.push(
+    await bumpedIndexFile(input.token, {
+      totalDelta: -removed,
+      shardCountDeltas,
+    }),
+  );
 
   const commit = await commitFilesWithRetry({
     files,

--- a/web/src/lib/optimistic.ts
+++ b/web/src/lib/optimistic.ts
@@ -1,0 +1,112 @@
+/**
+ * After a successful commit, the latest data is already in our hands —
+ * we just serialised it and pushed it to GitHub. The hard part is that
+ * raw.githubusercontent.com is fronted by Fastly with `Cache-Control:
+ * max-age=300`, so a refetch immediately after the commit will see the
+ * pre-edit shard for up to 5 minutes. That's why edits "didn't seem to
+ * stick" until the user happened to wait long enough (or hit a fresh
+ * browser context like an incognito window).
+ *
+ * Solution: optimistically write our known-fresh data into both caches:
+ *   1. TanStack Query — so the active table re-renders instantly.
+ *   2. IndexedDB     — so a reload still sees fresh data.
+ * Then the CDN catch-up happens in the background. The next natural
+ * refetch (5-minute staleTime, or pulling Refresh in the dashboard)
+ * sees the same data and is a no-op.
+ */
+import type { QueryClient } from "@tanstack/react-query";
+import type { GamesData } from "../hooks/useGames";
+import { writeCache } from "./cache";
+import { buildIndex, extractAppid } from "./data-store";
+import type { EditPatch } from "./edits";
+import type { GameRecord } from "./schema";
+
+const QUERY_KEY = ["games", "all"] as const;
+
+function nowIsoSeconds(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function applyPatchTo(record: GameRecord, patch: EditPatch): GameRecord {
+  const out = { ...record };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) continue;
+    (out as unknown as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
+function commit(qc: QueryClient, mutate: (records: GameRecord[]) => GameRecord[]) {
+  const data = qc.getQueryData<GamesData>(QUERY_KEY as unknown as string[]);
+  if (!data) return;
+  const records = mutate(data.records);
+  const next: GamesData = {
+    records,
+    index: {
+      ...data.index,
+      total: records.length,
+      last_updated: nowIsoSeconds(),
+    },
+    appidIndex: buildIndex(records),
+  };
+  qc.setQueryData<GamesData>(QUERY_KEY as unknown as string[], next);
+  void writeCache({ records: next.records, index: next.index });
+}
+
+/** Apply a patch to a single record in-place (matched by flatIndex). */
+export function optimisticEdit(
+  qc: QueryClient,
+  flatIndex: number,
+  patch: EditPatch,
+): void {
+  commit(qc, (records) => {
+    if (flatIndex < 0 || flatIndex >= records.length) return records;
+    const next = records.slice();
+    next[flatIndex] = applyPatchTo(next[flatIndex], patch);
+    return next;
+  });
+}
+
+/** Replace one record entirely (JSON-mode edit). */
+export function optimisticReplace(
+  qc: QueryClient,
+  flatIndex: number,
+  replacement: GameRecord,
+): void {
+  commit(qc, (records) => {
+    if (flatIndex < 0 || flatIndex >= records.length) return records;
+    const next = records.slice();
+    next[flatIndex] = replacement;
+    return next;
+  });
+}
+
+/** Apply the same patch to every record matching one of these appids. */
+export function optimisticBulkEdit(
+  qc: QueryClient,
+  appids: Iterable<string>,
+  patch: EditPatch,
+): void {
+  const set = new Set(appids);
+  commit(qc, (records) =>
+    records.map((r) => {
+      const aid = extractAppid(r.link);
+      if (aid && set.has(aid)) return applyPatchTo(r, patch);
+      return r;
+    }),
+  );
+}
+
+/** Drop records whose appid is in the set. */
+export function optimisticBulkDelete(
+  qc: QueryClient,
+  appids: Iterable<string>,
+): void {
+  const set = new Set(appids);
+  commit(qc, (records) =>
+    records.filter((r) => {
+      const aid = extractAppid(r.link);
+      return !(aid && set.has(aid));
+    }),
+  );
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -45,14 +45,23 @@ export default defineConfig(({ command }) => ({
         globPatterns: ["**/*.{js,css,html,svg,woff2}"],
         navigateFallback: command === "build" ? `/${repoName}/index.html` : "/index.html",
         runtimeCaching: [
-          // Raw shard data — stale-while-revalidate so offline users see the
-          // last-known catalog and online users get fresh data shortly after.
+          // Raw shard data — NetworkFirst so an edit lands on disk → next page
+          // load fetches the fresh shard, with cache fallback when offline.
+          // Old StaleWhileRevalidate strategy made edits appear only after TWO
+          // reloads (cached on first, refreshed in background, returned on
+          // second). Using NetworkFirst with a short timeout keeps offline UX
+          // intact while making edits visible on the next reload.
+          //
+          // The cache name is bumped to `f2p-data-v2` so users with a stale
+          // SW automatically discard the old entries on activation rather
+          // than serving them from the legacy `f2p-data` cache.
           {
             urlPattern:
               /^https:\/\/raw\.githubusercontent\.com\/poli0981\/free-steam-games-list\/main\/data\/.*/,
-            handler: "StaleWhileRevalidate",
+            handler: "NetworkFirst",
             options: {
-              cacheName: "f2p-data",
+              cacheName: "f2p-data-v2",
+              networkTimeoutSeconds: 5,
               expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 7 },
               cacheableResponse: { statuses: [0, 200] },
             },


### PR DESCRIPTION
## Diagnosis

Phase 6.2 fixed two layers of caching but missed a third: **raw.githubusercontent.com is Fastly-cached for 5 minutes**.

\`\`\`
$ curl -sI https://raw.githubusercontent.com/poli0981/free-steam-games-list/main/data/index.json
Cache-Control: max-age=300
X-Served-By: cache-sin-wsat1880056-SIN
\`\`\`

So the sequence was:

1. Edit → commit lands on api.github.com **immediately** (verified ✓)
2. UI calls \`qc.invalidateQueries([\"games\"])\` → forced refetch
3. Refetch hits raw.github via Workbox NetworkFirst — **CDN edge still serves the pre-edit shard for up to 5 min**
4. Editor sees stale data, thinks the save didn't apply
5. ~5 min later they log out / reload, CDN has refreshed → \"only works when logged out\"

The bug looked auth-related but was just timing.

## Fix

Don't go through the CDN at all for the editor's own commit. We already serialised the new records locally — write them straight to:

- **TanStack Query cache** (\`qc.setQueryData(...)\`) → table re-renders instantly with the new state.
- **IndexedDB** (\`writeCache(...)\`) → reload still shows fresh data.

The CDN catch-up happens entirely in the background. The next natural 5-minute \`staleTime\` refetch sees the same content and is a no-op.

New \`lib/optimistic.ts\` helpers:

| Helper | Used by |
|---|---|
| \`optimisticEdit(qc, flatIndex, patch)\` | EditGameDrawer (form mode) |
| \`optimisticReplace(qc, flatIndex, replacement)\` | EditGameDrawer (JSON mode) |
| \`optimisticBulkEdit(qc, appids, patch)\` | BulkEditDrawer |
| \`optimisticBulkDelete(qc, appids)\` | BulkActionBar |

Each helper bumps \`index.last_updated\` and \`total\` locally to match what we just wrote on disk, so a later refetch's \`isCacheFresh()\` check stays true.

\`addLinks\` doesn't need this — \`scripts/temp_info.jsonl\` entries don't appear in the records array until the ingest pipeline materialises them.

\`RefAdvancedError\` still falls back to a real \`invalidateQueries\` since our in-memory state is invalid in that race.

## Test plan

- [x] tsc --noEmit clean
- [x] vite build 3.74 s
- [ ] After merge: edit any record → save → table updates **instantly** with the new value (no waiting, no extra reload).
- [ ] Reload immediately after save → row still reflects the edit (IndexedDB has it).
- [ ] Wait 5+ min, hard reload → still correct (CDN has caught up by now too).
- [ ] Bulk delete two rows → both disappear instantly; total drops by 2.
- [ ] If a daily-pipeline race triggers RefAdvancedError → real refetch, fresh state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)