### PR TITLE
Phase 7: date-sort fix + hamburger nav + About expansion + legal rewrite + Node 24

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,11 +25,11 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: web/dist
 
@@ -55,4 +55,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,8 @@ artifacts/
 # Add any project-specific files or directories to ignore below
 [Nn]ote.txt
 [Nn]ote.md
+[Nn]otes.txt
+[Nn]otes.md
 temp_data/
 debug_info/
 countdata.py

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -1,15 +1,62 @@
 # DISCLAIMER
 
-**This repository is provided "AS IS" without warranty of any kind**, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, title, and non-infringement. In no event shall the author(s) or copyright holder(s) be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the repository or the use or other dealings in its contents.
+**This repository — including its data, scripts, web app, and documentation — is provided "AS IS" without warranty of any kind**, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, title, accuracy, completeness, and non-infringement. In no event shall the author(s) or copyright holder(s) be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the repository or the use or other dealings in its contents.
 
-### Additional Notes from the Broke, Unemployed Maintainer (a.k.a. Me):
-- **No quality guarantees whatsoever.** Most games on this list are just scraped/added because they're marked free-to-play on Steam. I only kinda-sorta vouch for the ones I've actually played (check the "Personal Experience" or "Safe?" column if it exists – my standards are low anyway).
-- **Problems with a game?** Bugs, pay-to-win hell, toxic community, crashes, whatever – that's between you, Valve/Steam, and the developers. Do NOT contact me. I'm literally just a guy making a list while procrastinating on life.
-- **Completeness & Accuracy:** This list is **DEFINITELY NOT 100% complete or accurate**. Games change status, get delisted, go paid, or die overnight. I miss stuff. Deal with it.
-- **Malware/Viruses/Safety:** Who knows? Steam is generally safe, but I'm not your antivirus. I'll try to add a column/note for games I've personally played and think are clean(ish), but scan everything yourself. No promises.
-- **Updates?** Whenever I feel like it. Daily? Every 3 days? Weekly? When boredom hits level 100 and caffeine kicks in. No schedule, no promises. This is a hobby project by a jobless introvert, not a corporation.
-- **Thinking of suing me?** Lmao, good luck. I'm broke, have zero assets except a Steam library full of sale games, and this is literally just a curated list. You'd get more value farming achievements in the games listed here.
+The MIT License (see [LICENSE](../LICENSE)) is the actual binding instrument. Everything below is supplemental — bullet points, not legalese — written so a human can understand the limits before relying on this list.
 
-This project is licensed under the MIT License – see the [LICENSE](LICENSE) file for details. The MIT License already includes strong disclaimer language, but I added this file because paranoia is free.
+---
 
-Last updated: Whenever I remembered to.
+### Notes from the broke, unemployed maintainer (a.k.a. me)
+
+- **No quality guarantees whatsoever.** Most games on the list got there because they're flagged free-to-play on Steam by the daily pipeline. The maintainer only kinda-sorta vouches for games personally played; check the `safe` column for that.
+
+- **Bugs / pay-to-win / toxic community / crashes** in any game are between you, Valve, and the developer of that game. Do not contact the maintainer about them.
+
+- **Definitely not 100 % complete or accurate.** Games change status, get delisted, flip to paid, or disappear overnight. Things get missed. Cross-reference the Steam page before forming an opinion.
+
+- **Updates** happen whenever the maintainer feels like it (typically the GitHub Actions pipeline runs daily, but the maintainer manually overrides plenty). No SLA. This is a hobby.
+
+- **Suing the maintainer:** the maintainer is broke, has zero relevant assets, and lives in Vietnam. Costs of action will exceed any plausible recovery. Save your money.
+
+---
+
+### Specific accuracy caveats
+
+These are the known classes of error you should expect when relying on the data:
+
+1. **Genre is best-effort and frequently wrong for hybrids.**
+   The pipeline assigns one `genre` per game by reading the Steam-provided tag list and parsing the description text. For straightforward titles (FPS, MOBA, racing) it's usually right. For hybrids ("ARPG with deck-building roguelike elements"), indie experiments, or VR / educational titles, it picks one bucket and discards the rest. Use the `tags` field for the unfiltered Steam-tag set when you need accuracy.
+
+2. **English-language assumption is hard-baked.**
+   The HTML scraper, Python ingest pipeline, and the web-app filters all assume Steam pages and their search/store responses are returned in English. Steam's regional storefronts (`store.steampowered.com/?cc=jp`, `&cc=de`, etc.) sometimes localise game titles, genre strings, language-support tables, and DLC descriptions. If you hit the data via a regional storefront — or if Steam silently changes its localisation behaviour — names, genres, language counts, and DLC flags can come back wrong. Run anything important against the canonical EN page.
+
+3. **Test-data leakage.**
+   While building the web app, the maintainer ran live edit / add / delete tests against the production repo. Some test commits bumped genre/notes/anti-cheat fields on real games, and a handful of "queue 1 game for ingest" entries may have introduced dummy rows that the daily pipeline later cleaned up. If a row looks like it was edited mid-test (default values, joke notes), file a [Bug Report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml).
+
+4. **"Unsigned" commits in `Activity` are mostly dev artefacts.**
+   The web app signs commits via the maintainer's OpenPGP key only when the key is unlocked in the browser session. Many commits that landed during development happened with the key locked — they show as `unsigned` rather than `Verified ✓`. They are not malicious; they're just lock-state artefacts. If you depend on Verified-only commits for trust, filter to Verified in the activity feed.
+
+5. **Anti-cheat assessments come from regex over text.**
+   `anti_cheat`, `is_kernel_ac`, and `anti_cheat_note` are populated by matching known AC names (VAC, EAC, BattlEye, Vanguard, …) against the Steam page text. If a game ships an AC under a vendor-renamed brand or only mentions it in a launcher EULA, the field will be `-`. Cross-check before relying on this for kernel-driver risk decisions.
+
+6. **Player counts are sampled, not realtime.**
+   `current_players` and `peak_today` come from periodic Steam Web API calls and lag by minutes-to-hours.
+
+7. **Malware / safety flags are not antivirus output.**
+   The `safe` field is a manual `y / n / ?` set by the maintainer based on personal experience or third-party reports. Run your own antivirus.
+
+---
+
+### Malware / viruses / safety
+
+Steam's own platform has its own safety guarantees and policies — they are the relevant authority here. The maintainer is not your antivirus. Scan everything yourself. Do not assume `safe = "y"` means audited; it means "the maintainer played it and didn't get pwned, but no formal review."
+
+### Updates
+
+Whenever the maintainer remembers, plus whatever the GitHub Actions cron schedules. No fixed cadence, no on-call.
+
+---
+
+This project is licensed under the MIT License — see the [LICENSE](../LICENSE) file. The MIT text already includes broad disclaimer language; this file restates and extends it because (a) accuracy caveats deserve their own section, and (b) paranoia is free.
+
+Last updated: whenever the maintainer remembered.

--- a/docs/EULA.md
+++ b/docs/EULA.md
@@ -1,21 +1,55 @@
 # END USER LICENSE AGREEMENT (EULA)
 
-**Wait, what?** This is literally just a curated list of free Steam games on GitHub, licensed under MIT. There is no "software" to install, no executable, no nothing. But since you're here and apparently love legal documents more than free games...
+**Short version:** the entire repository — data, scripts, web app, and docs — is licensed under the [MIT License](../LICENSE). The MIT text is the actual binding instrument. This file is supplemental commentary in plain language.
 
-By accessing, viewing, forking, starring, or even thinking about this repository, you agree to the following:
+There is no installable software, no executable, no SaaS contract, no subscription, no telemetry. The "product" is a Markdown / JSONL list of free-to-play Steam games plus a static, client-side web app that reads it. By accessing, viewing, forking, starring, cloning, redistributing, or otherwise interacting with this repository or the deployed Pages site, you agree to the terms below.
 
-1. **The MIT License is the Real Boss:** Everything is governed by the MIT License (see [LICENSE](LICENSE)). That's it. That's the actual legal stuff.
-2. **No Actual Product Here:** You're not "using" software – you're reading a Markdown list made by a broke, unemployed dev in his free time (which is all the time).
-3. **Your Responsibilities:** 
-   - Play games at your own risk.
-   - Don't blame me if a game sucks, has microtransactions from hell, or eats your CPU.
-   - If something breaks your PC/brain/soul, talk to Valve or the devs – not me.
-4. **My Responsibilities:** Zero. Zilch. Nada. I might update the list when bored, or not.
-5. **Termination:** If you violate these terms (good luck figuring out how), I reserve the right to... laugh and do nothing, because I'm not a company.
-6. **Governing Law:** Vietnam (probably), common sense, and whatever GitHub enforces.
+---
 
-This EULA is mostly a joke because it's overkill for a game list. The real license is MIT – short, sweet, and actually enforceable.
+### 1. Governing licence
 
-If you're a lawyer reading this: congrats, you've wasted your time. Go play a free game instead.
+The MIT License governs everything. Read [`LICENSE`](../LICENSE) — it is short and unambiguous. If anything in this EULA conflicts with the MIT text, the MIT text wins.
 
-Last updated: Whenever I felt like it.
+### 2. Nature of the work
+
+You are not "using" software in the traditional sense. You are reading a curated list and, optionally, viewing it through a static client-side web app. There is no backend, no server-side processing of your data, no account.
+
+### 3. Your responsibilities
+
+- Play games from the list at your own risk. Steam's own [Subscriber Agreement](https://store.steampowered.com/subscriber_agreement/) and [refund policy](https://store.steampowered.com/steam_refunds/) govern your relationship with Valve and the game developers.
+- Do not blame the maintainer if a game is bad, predatory, addictive, riddled with microtransactions, has a kernel-level anti-cheat that conflicts with your system, or any other complaint that is fundamentally about the game and not about this list.
+- Do your own malware / safety due diligence. The `safe` and `anti_cheat` columns are best-effort signals from a single person, not audited output.
+- If you fork the repository or build a derivative work, the MIT terms travel with you. Attribute appropriately.
+
+### 4. Maintainer's responsibilities
+
+- The maintainer commits to nothing. There is no SLA, no uptime guarantee, no roadmap obligation, no support contract, no response-time promise.
+- The pipeline runs daily under GitHub Actions on a best-effort basis. Workflow runs may fail, be paused, or be re-architected without notice.
+
+### 5. Accuracy notice (incorporated by reference)
+
+[`DISCLAIMER.md`](./DISCLAIMER.md) lists specific known-error classes — genre best-effort, English-language assumption, test-data leakage, unsigned-commit artefacts, AC regex limits, sampled player counts, manual safe-flag scope. Read it before relying on any individual data point.
+
+### 6. Trademarks
+
+- **Steam**, the **Steam logo**, **Steam Store**, **Steam Community**, **Valve Anti-Cheat**, **VAC**, and related marks are trademarks of Valve Corporation. Their use here is descriptive / nominative; the project is independent and not affiliated with, endorsed by, or sponsored by Valve.
+- **GitHub** and the **GitHub Actions** marks are trademarks of GitHub, Inc.
+- All other game titles, developer names, publisher names, and logos in the data are property of their respective owners. Their inclusion is descriptive (the same way a directory or review aggregator names games) and does not imply endorsement.
+
+### 7. Termination
+
+If you breach the MIT License, your rights under it terminate per the licence text. The maintainer additionally reserves the right to ignore disputes, decline pull requests, and laugh at cease-and-desist letters that are addressed to a hobby project on a public GitHub repo.
+
+### 8. Governing law
+
+Vietnam, plus whatever the MIT License + GitHub Terms of Service require. The maintainer is not a lawyer; this document is not legal advice.
+
+### 9. Changes
+
+This document may be updated to reflect actual project changes. Continued access after an update means you accept the new version. Diffs are visible in the repo's commit history.
+
+---
+
+If you are a lawyer reading this for a real reason: I'd rather you open an issue than draft a letter. Open-source maintainers respond better to GitHub mentions than to certified mail.
+
+Last updated: whenever the maintainer remembered.

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,18 +1,72 @@
 # PRIVACY POLICY
 
-**Effective Date: Whenever this repo was created (I'm too lazy to check)**
+**Effective date:** whenever this file was first committed (see git history). Updates are documented in commit log.
 
-### Short Version (TL;DR):
-This repository collects **ZERO personal data**. Nothing. Nada. Zilch.
+### Short version
 
-No tracking, no analytics, no cookies (this isn't even a website), no user accounts, no nothing. It's just Markdown files and maybe a JSON list on GitHub.
+This repository and the static Pages site at <https://poli0981.github.io/free-steam-games-list/> collect **no personal data on the maintainer's side**.
 
-### Detailed Version (Because You Asked for Super Detailed):
-- **What data do I collect?** None from you directly. This is a static GitHub repo.
-- **GitHub's platform:** If you star, fork, open issues, or contribute, that's handled by GitHub. Their privacy policy applies – check it here: https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement
-- **No third-party stuff:** No external scripts, no trackers, no AI scraping your info (except me occasionally asking Grok for help updating the list, but that's on my end).
-- **Changes to this policy:** If I ever add something crazy (unlikely), I'll update this file. But probably never.
+There is no backend, no server-side log, no analytics SDK, no advertising tracker, no fingerprinting library. Everything happens client-side in your browser, against either GitHub's API or `raw.githubusercontent.com`.
 
-I'm an unemployed dev with no server, no backend, and no motivation to collect data. Why would I? I can barely collect motivation to update the game list.
+---
 
-Questions? Open an issue, but honestly, there's nothing to ask.
+### What the maintainer does NOT collect
+
+- No accounts, sign-ups, or sessions on this side.
+- No analytics. No Google Analytics, Plausible, Fathom, etc.
+- No cookies set by this domain.
+- No advertising / behavioural-ad tracking.
+- No fingerprinting.
+- No server-side request logging — there is no server other than GitHub's CDN.
+- No data sent to third-party SDKs.
+
+### What runs in your browser
+
+The static web app fetches:
+
+- `https://raw.githubusercontent.com/poli0981/free-steam-games-list/main/data/*.jsonl` — the game data.
+- `https://api.github.com/...` — only when the user signs in with their own GitHub PAT for editing/adding/deleting. Never from anonymous visitors.
+- `https://shared.akamai.steamstatic.com/store_item_assets/.../header.jpg` — Steam game header images. Each `<img>` tag emits an HTTP GET to Akamai; Akamai's standard CDN logs apply.
+- `https://avatars.githubusercontent.com/...` — the signed-in user's avatar, only when authenticated.
+
+These third-party endpoints have their own privacy policies and may log your IP / User-Agent according to their terms:
+
+- **GitHub** — [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+- **Akamai** — see Steam's [Privacy Policy](https://store.steampowered.com/privacy_agreement/) (Akamai is Steam's CDN).
+
+### What stays local in your browser
+
+The web app uses three local-storage mechanisms:
+
+1. **`localStorage`** — your GitHub PAT (only if you sign in), your selected GPG key (encrypted by the key's own passphrase), your theme + auto-lock preferences. Nothing is uploaded.
+2. **IndexedDB** — a cache of the JSONL records keyed on `data/index.json.last_updated`, so reloads are fast. Nothing is uploaded.
+3. **Service Worker cache** — the app shell + the last-known data shards, for offline browsing. Nothing is uploaded.
+
+You can clear all of the above at any time via your browser's site-data settings ("Clear site data" works fully).
+
+### What the *editing* path actually sends
+
+Only when you sign in and edit, add, or delete:
+
+- Your PAT goes only to `api.github.com`, never anywhere else.
+- The commits you make are public on the repo and visible to anyone — that is by design. Author and committer email come from your GPG key's user ID (when unlocked) or from GitHub's noreply email format (when the key is locked). The web app never alters these without your input.
+
+### LLM / AI
+
+About 70 % of the code in this repo was generated with help from Grok (v1) and Claude (v2+). Those LLM calls happen on the maintainer's development machine — never from your browser. No user data is sent to any AI service at runtime.
+
+### Children
+
+This is a directory of free-to-play Steam games. Steam itself has age-rating guidance per game; consult that before letting minors install anything found here. The maintainer does not moderate game content for age-appropriateness.
+
+### Changes
+
+If anything in this policy changes (it probably won't), the diff is in the repo commit history.
+
+### Contact
+
+Open an issue or use any of the channels listed in [`Contact.md`](./Contact.md). Privacy-specific questions: tag the issue `privacy`.
+
+---
+
+The maintainer has no server, no backend, and no commercial motive to collect user data — and is not interested in starting now.

--- a/docs/ToS.md
+++ b/docs/ToS.md
@@ -1,18 +1,61 @@
 # TERMS OF USE
 
-By accessing, forking, contributing to, or otherwise using this repository ("free-steam-games-list"), you agree to these Terms of Use and the MIT License (see [LICENSE](LICENSE) file).
+By accessing, forking, contributing to, mirroring, scraping, or otherwise using this repository (`free-steam-games-list`) or the deployed Pages site, you agree to these Terms of Use, the [MIT License](../LICENSE), and the supplemental [Disclaimer](./DISCLAIMER.md). The MIT text governs in case of conflict.
 
-### Key Points:
-1. **Use at Your Own Risk:** The content is just a curated list of free-to-play games on Steam. Download/play games entirely at your own discretion and risk.
-2. **No Endorsement or Guarantees:** Inclusion in the list does **not** mean I recommend, endorse, or guarantee quality, safety, fairness, or anything. Most are added because they're free – that's it.
-3. **Liability? What Liability?** See the DISCLAIMER.md – I'm not responsible for anything. Bad games, wasted time, toxic players, surprise microtransactions – not my problem.
-4. **Contributions:** Welcome! Feel free to open PRs to add/remove games, but I might reject if it doesn't fit my chaotic vibe. Follow the MIT License for any code/data you add.
-5. **No Commercial Drama:** You can use/fork/modify under MIT rules, but don't blame me if you build something on top and it blows up.
-6. **Updates & Maintenance:** Zero promises. I update when I want (see DISCLAIMER for the chaotic schedule).
-7. **Governing Law:** Whatever GitHub says, plus common sense. I'm in Vietnam, broke, and not a lawyer.
+---
 
-These terms can change anytime (I'll update the file if I remember). Continued use means you accept changes.
+### 1. Use at your own risk
 
-This is overkill for a simple list repo, but hey – better safe than sorry when you're unemployed and paranoid :))
+The repository is a curated list of free-to-play games on Steam plus a static web app reading the same list. Your decisions to download, install, run, or play any listed game are entirely your own.
 
-Questions? Issues welcome, but keep it chill.
+### 2. No endorsement, no quality guarantee
+
+Inclusion in the list is **not** an endorsement, recommendation, or warranty. Most entries are added because they are flagged free-to-play on Steam by the daily pipeline, not because they were reviewed or vouched for. The `safe` field reflects the maintainer's personal usage only, not a formal audit.
+
+### 3. Specific accuracy caveats
+
+You acknowledge the following:
+
+1. **Genre is heuristic.** The genre column is derived from Steam tags + a description-text parser. Hybrids, indie experiments, and non-traditional titles are frequently mis-bucketed. Use the `tags` array for the unfiltered set.
+2. **English-only assumptions.** The scraper, ingest pipeline, and web app assume Steam responses come back in English. Regional storefronts can return localised strings that break parsing. Names, genres, language-support tables, and DLC flags can be wrong for non-EN sessions. Compare against the canonical EN store page before acting on the data.
+3. **Test data may have leaked in.** During web-app development, the maintainer ran live edit / add / delete tests against the production repo. Some rows may carry test artefacts; the daily pipeline cleans most of these up but stragglers exist.
+4. **`unsigned` Activity entries are dev artefacts.** Many commits during development were made while the GPG key was locked. They are not malicious — just unsigned. If you require Verified-only trust, filter the Activity feed accordingly.
+5. **Anti-cheat detection is regex-based.** `anti_cheat` / `is_kernel_ac` are populated by matching known AC names against page text; rebrands and launcher-only mentions are missed.
+6. **Player counts are sampled.** `current_players` and `peak_today` lag by minutes-to-hours.
+
+### 4. Liability
+
+See [`DISCLAIMER.md`](./DISCLAIMER.md). Short version: the maintainer is not responsible for anything related to the listed games or the data. Bad games, wasted time, toxic players, surprise microtransactions, kernel-AC conflicts — not the maintainer's problem.
+
+### 5. Contributions
+
+Pull requests are welcome but optional to merge. By submitting a contribution you license it under the same MIT terms as the rest of the repo. Don't include code or data you don't have the right to share.
+
+### 6. Trademarks & third-party content
+
+- Steam, the Steam logo, VAC, BattlEye, EAC, Vanguard, etc., are trademarks of their respective owners. Their use here is descriptive / nominative.
+- Game titles, screenshots (header images served from Akamai's `shared.akamai.steamstatic.com`), developer names, and publisher names belong to their respective owners. Their inclusion in a list does not imply endorsement of this project by them, or vice versa.
+
+### 7. Forking, mirroring, derivative works
+
+Allowed under the MIT terms. Carry the licence text with you and attribute the original repo. If you build something that financially benefits from the list, you are not obligated to share the proceeds — but a "thanks" via [Ko-fi / Patreon](https://ko-fi.com/skullmute) is appreciated.
+
+### 8. No commercial drama
+
+You can fork and modify; the maintainer can't help if your downstream project blows up, gets DMCA'd, or has a launch-day disaster. The MIT licence's no-warranty clause covers this.
+
+### 9. Updates
+
+Zero promises. Updates happen on the maintainer's whim plus GitHub Actions cron. The `last_updated` field in `data/index.json` is the canonical timestamp.
+
+### 10. Governing law
+
+Whatever GitHub's Terms of Service require, plus Vietnamese law where applicable, plus common sense. The maintainer is not a lawyer; nothing here is legal advice.
+
+### 11. Changes to these terms
+
+This document may change without notice. The repo commit history is the change log. Continued use means acceptance of the latest version.
+
+---
+
+Questions: open an [issue](https://github.com/poli0981/free-steam-games-list/issues). Keep it civil; off-topic / spam will be ignored.

--- a/web/src/components/games/GamesTable.tsx
+++ b/web/src/components/games/GamesTable.tsx
@@ -15,7 +15,12 @@ import {
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { useFilters, PAGE_SIZES, type PageSize } from "../../stores/filters";
-import { formatNumber, parseIntSafe, parseReviewPercent } from "../../lib/utils";
+import {
+  formatNumber,
+  parseIntSafe,
+  parseReleaseDate,
+  parseReviewPercent,
+} from "../../lib/utils";
 import { extractAppid } from "../../lib/data-store";
 import type { GameRecord } from "../../lib/schema";
 import { cn } from "../../lib/utils";
@@ -174,7 +179,10 @@ const COLS: ColDef[] = [
     label: "Released",
     width: 120,
     sortable: true,
-    sortValue: (g) => g.release_date ?? "",
+    // Parse Steam-style date strings ("22 Aug, 2012") to timestamps —
+    // string-compare sorts "22 Aug, 2012" < "3 Jan, 2025" alphabetically
+    // and would scramble years entirely.
+    sortValue: (g) => parseReleaseDate(g.release_date),
     render: (g) => (
       <span className="text-xs text-muted-foreground">{g.release_date || "—"}</span>
     ),

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,22 +1,25 @@
 import { Outlet } from "react-router-dom";
-import { Sidebar } from "./Sidebar";
+import { useState } from "react";
+import { Sidebar, MobileSidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 import { CommandPalette } from "../common/CommandPalette";
 import { useGpgAutolock } from "../../hooks/useGpgAutolock";
 
 export function Layout() {
   useGpgAutolock();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar />
       <div className="flex min-w-0 flex-1 flex-col">
-        <Topbar />
+        <Topbar onMenuToggle={() => setMobileNavOpen(true)} />
         <main className="flex-1 overflow-y-auto">
           <div className="container max-w-screen-2xl py-6">
             <Outlet />
           </div>
         </main>
       </div>
+      <MobileSidebar open={mobileNavOpen} onOpenChange={setMobileNavOpen} />
       <CommandPalette />
     </div>
   );

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
+import { useEffect } from "react";
 import { useIsOwner } from "../../hooks/useIsOwner";
 import {
   LayoutDashboard,
@@ -20,6 +21,7 @@ import {
   Info,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { Sheet, SheetContent } from "../ui/sheet";
 
 interface NavItem {
   to: string;
@@ -58,11 +60,17 @@ const SECONDARY: NavItemWithOwner[] = [
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 
-function Item({ item }: { item: NavItem }) {
+interface ItemProps {
+  item: NavItem;
+  onSelect?: () => void;
+}
+
+function Item({ item, onSelect }: ItemProps) {
   return (
     <NavLink
       to={item.to}
       end={item.end}
+      onClick={onSelect}
       className={({ isActive }) =>
         cn(
           "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
@@ -78,11 +86,16 @@ function Item({ item }: { item: NavItem }) {
   );
 }
 
-export function Sidebar() {
+interface SidebarBodyProps {
+  onSelect?: () => void;
+}
+
+/** Inner content shared between desktop sidebar + mobile drawer. */
+function SidebarBody({ onSelect }: SidebarBodyProps) {
   const isOwner = useIsOwner();
   const visibleSecondary = SECONDARY.filter((i) => !i.ownerOnly || isOwner);
   return (
-    <aside className="hidden w-60 shrink-0 border-r bg-card/40 lg:flex lg:flex-col">
+    <>
       <div className="flex h-14 items-center gap-2 border-b px-4">
         <div className="grid h-8 w-8 place-items-center rounded-md bg-primary/15 text-primary">
           <Gamepad2 className="h-4 w-4" />
@@ -96,7 +109,7 @@ export function Sidebar() {
       <nav className="flex-1 space-y-6 overflow-y-auto px-2 py-4">
         <div className="space-y-1">
           {PRIMARY.map((i) => (
-            <Item key={i.to} item={i} />
+            <Item key={i.to} item={i} onSelect={onSelect} />
           ))}
         </div>
 
@@ -106,7 +119,7 @@ export function Sidebar() {
           </div>
           <div className="space-y-1">
             {CHARTS.map((i) => (
-              <Item key={i.to} item={i} />
+              <Item key={i.to} item={i} onSelect={onSelect} />
             ))}
           </div>
         </div>
@@ -117,7 +130,7 @@ export function Sidebar() {
           </div>
           <div className="space-y-1">
             {visibleSecondary.map((i) => (
-              <Item key={i.to} item={i} />
+              <Item key={i.to} item={i} onSelect={onSelect} />
             ))}
           </div>
         </div>
@@ -129,10 +142,45 @@ export function Sidebar() {
           target="_blank"
           rel="noreferrer"
           className="hover:text-foreground"
+          onClick={onSelect}
         >
           poli0981 / free-steam-games-list
         </a>
       </div>
+    </>
+  );
+}
+
+export function Sidebar() {
+  return (
+    <aside className="hidden w-60 shrink-0 border-r bg-card/40 lg:flex lg:flex-col">
+      <SidebarBody />
     </aside>
+  );
+}
+
+interface MobileSidebarProps {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+}
+
+/**
+ * Mobile-only sheet that mirrors the desktop sidebar. Auto-closes on route
+ * change so tapping a nav item works as expected without an extra X click.
+ */
+export function MobileSidebar({ open, onOpenChange }: MobileSidebarProps) {
+  const location = useLocation();
+  useEffect(() => {
+    if (open) onOpenChange(false);
+    // We only want to react to the location pathname change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="left" className="flex w-72 flex-col p-0">
+        <SidebarBody onSelect={() => onOpenChange(false)} />
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/web/src/components/layout/Topbar.tsx
+++ b/web/src/components/layout/Topbar.tsx
@@ -1,4 +1,4 @@
-import { Search, Sun, Moon, Monitor, ShieldCheck, Unlock } from "lucide-react";
+import { Search, Sun, Moon, Monitor, ShieldCheck, Unlock, Menu } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Input } from "../ui/input";
@@ -25,7 +25,12 @@ function applyTheme(t: Theme) {
   }
 }
 
-export function Topbar() {
+interface TopbarProps {
+  /** Hamburger handler — only shown on viewports without the desktop sidebar. */
+  onMenuToggle?: () => void;
+}
+
+export function Topbar({ onMenuToggle }: TopbarProps = {}) {
   const search = useFilters((s) => s.search);
   const setSearch = useFilters((s) => s.setSearch);
   const games = useGames();
@@ -58,6 +63,16 @@ export function Topbar() {
 
   return (
     <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Open menu"
+        className="-ml-2 lg:hidden"
+        onClick={onMenuToggle}
+      >
+        <Menu className="h-4 w-4" />
+      </Button>
+
       <div className="relative flex-1 max-w-xl">
         <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+export const Sheet = DialogPrimitive.Root;
+export const SheetTrigger = DialogPrimitive.Trigger;
+export const SheetClose = DialogPrimitive.Close;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = "SheetOverlay";
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: "left" | "right";
+}
+
+export const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = "left", className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed top-0 z-50 h-full w-72 border bg-card p-0 shadow-2xl outline-none",
+        side === "left"
+          ? "left-0 border-r data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left"
+          : "right-0 border-l data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-3 top-3 rounded-sm opacity-70 transition-opacity hover:opacity-100">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+SheetContent.displayName = "SheetContent";

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -32,6 +32,26 @@ export function reviewLabel(reviews: string | undefined | null): string | null {
   return m ? m[1].trim() : null;
 }
 
+/**
+ * Convert a Steam-style release_date ("22 Aug, 2012", "Dec 19, 2025",
+ * "Coming Soon", "TBA", "" ...) to a comparable timestamp for sorting.
+ * Unparseable / future-unknown values get -Infinity so they cluster at the
+ * "asc" end (oldest first) and the "desc" end (newest first) regardless of
+ * direction — sliding them out of the way of the real data.
+ */
+export function parseReleaseDate(s: string | undefined | null): number {
+  if (!s) return -Infinity;
+  const trimmed = s.trim();
+  if (!trimmed) return -Infinity;
+  // Year-only ("2025") is also valid; Date.parse handles "1 Jan, 2025" etc.
+  const t = Date.parse(trimmed);
+  if (Number.isFinite(t)) return t;
+  // "2025" alone: try as year start.
+  const yearOnly = /^\d{4}$/.exec(trimmed);
+  if (yearOnly) return Date.UTC(parseInt(yearOnly[0], 10), 0, 1);
+  return -Infinity;
+}
+
 export function formatRelativeDate(iso: string | undefined): string {
   if (!iso) return "—";
   const d = new Date(iso);

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -11,6 +11,9 @@ import {
   Youtube,
   MessageCircle,
   Coffee,
+  Scale,
+  Sparkles,
+  AlertTriangle,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Badge } from "../components/ui/badge";
@@ -44,24 +47,30 @@ interface Dep {
   name: string;
   role: string;
   href: string;
+  /** SPDX identifier — see https://spdx.org/licenses */
+  license: string;
+  /** Optional direct link to the dep's LICENSE file. */
+  licenseHref?: string;
 }
 
 const DEPS: Dep[] = [
-  { name: "React 18", role: "UI runtime", href: "https://react.dev/" },
-  { name: "TypeScript 5", role: "type system", href: "https://www.typescriptlang.org/" },
-  { name: "Vite 5", role: "build + dev server", href: "https://vitejs.dev/" },
-  { name: "Tailwind CSS 3", role: "styling", href: "https://tailwindcss.com/" },
-  { name: "shadcn/ui (Radix)", role: "UI primitives", href: "https://ui.shadcn.com/" },
-  { name: "TanStack Query", role: "data fetching + caching", href: "https://tanstack.com/query" },
-  { name: "TanStack Table + Virtual", role: "1.2k-row virtualised table", href: "https://tanstack.com/table" },
-  { name: "Apache ECharts", role: "charts (treemap / heatmap / wordcloud / …)", href: "https://echarts.apache.org/" },
-  { name: "OpenPGP.js", role: "client-side commit signing", href: "https://openpgpjs.org/" },
-  { name: "Workbox + vite-plugin-pwa", role: "service worker + offline cache", href: "https://vite-pwa-org.netlify.app/" },
-  { name: "Zustand", role: "UI/state store", href: "https://zustand-demo.pmnd.rs/" },
-  { name: "Fuse.js", role: "fuzzy search", href: "https://www.fusejs.io/" },
-  { name: "cmdk", role: "command palette", href: "https://cmdk.paco.me/" },
-  { name: "lucide-react", role: "icons", href: "https://lucide.dev/" },
-  { name: "sonner", role: "toasts", href: "https://sonner.emilkowal.ski/" },
+  { name: "React 18", role: "UI runtime", href: "https://react.dev/", license: "MIT", licenseHref: "https://github.com/facebook/react/blob/main/LICENSE" },
+  { name: "TypeScript 5", role: "type system", href: "https://www.typescriptlang.org/", license: "Apache-2.0", licenseHref: "https://github.com/microsoft/TypeScript/blob/main/LICENSE.txt" },
+  { name: "Vite 5", role: "build + dev server", href: "https://vitejs.dev/", license: "MIT", licenseHref: "https://github.com/vitejs/vite/blob/main/LICENSE" },
+  { name: "Tailwind CSS 3", role: "styling", href: "https://tailwindcss.com/", license: "MIT", licenseHref: "https://github.com/tailwindlabs/tailwindcss/blob/main/LICENSE" },
+  { name: "Radix UI", role: "headless UI primitives", href: "https://www.radix-ui.com/", license: "MIT", licenseHref: "https://github.com/radix-ui/primitives/blob/main/LICENSE" },
+  { name: "TanStack Query", role: "data fetching + caching", href: "https://tanstack.com/query", license: "MIT", licenseHref: "https://github.com/TanStack/query/blob/main/LICENSE" },
+  { name: "TanStack Table + Virtual", role: "1.2k-row virtualised table", href: "https://tanstack.com/table", license: "MIT", licenseHref: "https://github.com/TanStack/table/blob/main/LICENSE" },
+  { name: "Apache ECharts", role: "treemap / heatmap / wordcloud / …", href: "https://echarts.apache.org/", license: "Apache-2.0", licenseHref: "https://github.com/apache/echarts/blob/master/LICENSE" },
+  { name: "echarts-wordcloud", role: "ECharts wordcloud plugin", href: "https://github.com/ecomfe/echarts-wordcloud", license: "BSD-3-Clause", licenseHref: "https://github.com/ecomfe/echarts-wordcloud/blob/master/LICENSE" },
+  { name: "OpenPGP.js", role: "client-side commit signing", href: "https://openpgpjs.org/", license: "LGPL-3.0", licenseHref: "https://github.com/openpgpjs/openpgpjs/blob/main/LICENSE" },
+  { name: "Workbox + vite-plugin-pwa", role: "service worker + offline cache", href: "https://vite-pwa-org.netlify.app/", license: "MIT", licenseHref: "https://github.com/vite-pwa/vite-plugin-pwa/blob/main/LICENSE" },
+  { name: "Zustand", role: "UI/state store", href: "https://zustand-demo.pmnd.rs/", license: "MIT", licenseHref: "https://github.com/pmndrs/zustand/blob/main/LICENSE" },
+  { name: "Fuse.js", role: "fuzzy search", href: "https://www.fusejs.io/", license: "Apache-2.0", licenseHref: "https://github.com/krisk/Fuse/blob/main/LICENSE" },
+  { name: "cmdk", role: "command palette", href: "https://cmdk.paco.me/", license: "MIT", licenseHref: "https://github.com/pacocoursey/cmdk/blob/main/LICENSE" },
+  { name: "lucide-react", role: "icons", href: "https://lucide.dev/", license: "ISC", licenseHref: "https://github.com/lucide-icons/lucide/blob/main/LICENSE" },
+  { name: "sonner", role: "toasts", href: "https://sonner.emilkowal.ski/", license: "MIT", licenseHref: "https://github.com/emilkowalski/sonner/blob/main/LICENSE.md" },
+  { name: "idb-keyval", role: "IndexedDB wrapper", href: "https://github.com/jakearchibald/idb-keyval", license: "Apache-2.0", licenseHref: "https://github.com/jakearchibald/idb-keyval/blob/main/LICENSE" },
 ];
 
 const ISSUE_TEMPLATES = [
@@ -70,6 +79,22 @@ const ISSUE_TEMPLATES = [
   { id: "add_games", label: "Add games", icon: PlusCircle, color: "text-emerald-400" },
   { id: "delete_game", label: "Delete game", icon: Shield, color: "text-violet-400" },
   { id: "feedback", label: "Feedback", icon: MessageCircle, color: "text-blue-400" },
+];
+
+interface LegalDoc {
+  label: string;
+  path: string;
+  hint: string;
+}
+
+const LEGAL_DOCS: LegalDoc[] = [
+  { label: "MIT License", path: "LICENSE", hint: "the actual binding terms — short and friendly" },
+  { label: "Disclaimer", path: "docs/DISCLAIMER.md", hint: "no warranty, accuracy caveats, liability shrug" },
+  { label: "Terms of Use", path: "docs/ToS.md", hint: "what you agree to by using the repo / site" },
+  { label: "EULA", path: "docs/EULA.md", hint: "redundant with MIT but exists for paranoia" },
+  { label: "Privacy Policy", path: "docs/PRIVACY_POLICY.md", hint: "no data collected by the site itself" },
+  { label: "Acknowledgements", path: "docs/ACKNOWLEDGEMENTs.md", hint: "credits to AI assistants + contributors" },
+  { label: "Contact", path: "docs/Contact.md", hint: "where to find me" },
 ];
 
 export function AboutPage() {
@@ -82,7 +107,8 @@ export function AboutPage() {
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">About</h1>
         <p className="text-sm text-muted-foreground">
-          The repo, the dev, the stack, and how to get bugs in front of me.
+          The repo, the dev, the stack, the legal stuff, and the fine print on
+          accuracy.
         </p>
       </div>
 
@@ -138,14 +164,93 @@ export function AboutPage() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-400" /> Heads-up before
+            you trust this
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <ul className="list-disc space-y-1.5 pl-5">
+            <li>
+              <strong>Genre is best-effort.</strong> The pipeline picks one genre
+              per game by reading Steam tags and parsing the description; for
+              hybrids and weird indie titles it can be wrong. The
+              <em> Edit </em> drawer lets the maintainer fix it manually.
+            </li>
+            <li>
+              <strong>English-language assumption.</strong> The scraper, ingest
+              pipeline, and this UI all assume Steam pages and search results
+              are in English. Steam regional storefront overrides can break
+              parsing — names / genres / DLC counts may end up incorrect for
+              non-EN users.
+            </li>
+            <li>
+              <strong>Test data may have leaked in.</strong> While building the
+              app, a handful of records were committed as part of testing
+              (edits, adds, deletes). They eventually get cleaned up by the
+              daily pipeline, but if you spot a row that looks off, file a
+              <em> Bug Report</em> issue.
+            </li>
+            <li>
+              <strong>"Unsigned" commits in the activity feed are mine.</strong>{" "}
+              Many of those are commits I made while the GPG key wasn't unlocked
+              during development; they're not malicious — just a lock-state
+              artefact, not signed.
+            </li>
+            <li>
+              <strong>This is not a Valve / Steam product.</strong> Independent
+              project, no affiliation, no support contract.
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-violet-400" /> AI disclosure
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            About <strong>~70 %</strong> of the code in this repository was
+            generated with the help of large-language-model assistants:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>
+              <strong>Grok</strong> — initial v1 Python pipeline (~2025).
+            </li>
+            <li>
+              <strong>Claude</strong> — v2 refactor, the Python data layer, this
+              entire web app, the GPG signing path, the legal docs you're
+              reading, and most of the recent commits.
+            </li>
+          </ul>
+          <p>
+            Generated code is reviewed and tested before each commit, but
+            mistakes happen — especially in subtle areas like commit-bytes
+            formatting (which we got wrong twice before fixing in 4.1) and
+            CDN-cache invalidation (fixed in 6.2). Please file an issue if you
+            see something off.
+          </p>
+          <p>
+            No user data is sent to any LLM at runtime. The only AI calls
+            happen on my dev machine while I'm writing code, never from your
+            browser.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
             <Heart className="h-4 w-4 text-rose-400" /> Maintained by SkullMute
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            One Vietnamese dev (poli0981 / SkullMute), 70% AI-assisted (Grok for v1,
-            Claude for v2+), running this in spare time. Hit me up on any of these
-            if something is broken or you want to chat:
+            One Vietnamese dev (poli0981 / SkullMute), running this in spare
+            time. Hit me up on any of these if something is broken or you want
+            to chat:
           </p>
           <div className="grid gap-2 sm:grid-cols-2">
             {SOCIALS.map((s) => (
@@ -202,39 +307,103 @@ export function AboutPage() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
+            <Scale className="h-4 w-4" /> Legal &amp; license
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            The whole repo (data, code, docs, this web app) is{" "}
+            <a
+              href={`${REPO_URL}/blob/main/LICENSE`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary hover:underline"
+            >
+              MIT-licensed
+            </a>
+            . Everything below is supplemental — the MIT terms still govern.
+          </p>
+          <ul className="space-y-1.5">
+            {LEGAL_DOCS.map((d) => (
+              <li
+                key={d.path}
+                className="flex items-center justify-between rounded-md border bg-card px-3 py-2 text-sm"
+              >
+                <a
+                  href={`${REPO_URL}/blob/main/${d.path}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium hover:text-primary"
+                >
+                  {d.label}
+                </a>
+                <span className="ml-2 truncate text-xs text-muted-foreground">
+                  {d.hint}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
             <FileText className="h-4 w-4" /> Stack &amp; third-party
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            All third-party libraries used by this app. The Python pipeline
-            relies on <code>requests</code> + <code>urllib3</code> only.
+            All third-party libraries used by this app, with their SPDX licence
+            identifiers. The Python pipeline relies on <code>requests</code> +{" "}
+            <code>urllib3</code> only (both Apache-2.0).
           </p>
           <ul className="space-y-1.5">
             {DEPS.map((d) => (
               <li
                 key={d.name}
-                className="flex items-center justify-between rounded-md border bg-card px-3 py-2 text-sm"
+                className="flex items-center justify-between gap-2 rounded-md border bg-card px-3 py-2 text-sm"
               >
                 <a
                   href={d.href}
                   target="_blank"
                   rel="noreferrer"
-                  className="font-medium hover:text-primary"
+                  className="min-w-0 truncate font-medium hover:text-primary"
                 >
                   {d.name}
                 </a>
-                <span className="text-xs text-muted-foreground">{d.role}</span>
+                <span className="hidden truncate text-xs text-muted-foreground sm:inline">
+                  {d.role}
+                </span>
+                {d.licenseHref ? (
+                  <a
+                    href={d.licenseHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="shrink-0"
+                    title={`${d.license} licence`}
+                  >
+                    <Badge variant="outline" className="font-mono">
+                      {d.license}
+                    </Badge>
+                  </a>
+                ) : (
+                  <Badge variant="outline" className="shrink-0 font-mono">
+                    {d.license}
+                  </Badge>
+                )}
               </li>
             ))}
           </ul>
           <Separator />
           <div className="text-xs text-muted-foreground">
-            Steam, Steam Store, Steam Community, and the Steam logo are trademarks
-            of Valve Corporation. This site is not affiliated with Valve.
+            Steam, Steam Store, Steam Community, and the Steam logo are
+            trademarks of Valve Corporation. This site is not affiliated with
+            Valve.
             <br />
-            Steam header images served from Akamai (<code>shared.akamai.steamstatic.com</code>).
-            Public-key search for commit verification uses <code>api.github.com</code>.
+            Steam header images served from Akamai (
+            <code>shared.akamai.steamstatic.com</code>). Public-key search for
+            commit verification uses <code>api.github.com</code>.
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

Bundles the items from \`notes.txt\` plus the date-sort bug.

- **Build:** \`tsc --noEmit\` clean, \`vite build\` 4.87 s.
- **Bundle:** index 113 KB gz (+4 KB for Sheet primitive + About expansions). All other chunks unchanged.

## What's in

| # | Item | File(s) |
|---|---|---|
| 1 | Date-column sort fix (parse Steam date strings → timestamp) | [\`utils.ts\`](web/src/lib/utils.ts), [\`GamesTable.tsx\`](web/src/components/games/GamesTable.tsx) |
| 2 | Hamburger mobile nav (Sheet drawer, auto-close on route change) | [\`sheet.tsx\`](web/src/components/ui/sheet.tsx), [\`Sidebar.tsx\`](web/src/components/layout/Sidebar.tsx), [\`Topbar.tsx\`](web/src/components/layout/Topbar.tsx), [\`Layout.tsx\`](web/src/components/layout/Layout.tsx) |
| 3 | About page: legal docs links, MIT licence, AI disclosure, accuracy caveats, per-third-party SPDX licences | [\`About.tsx\`](web/src/pages/About.tsx) |
| 4 | Legal docs rewritten with the four caveats from \`notes.txt\`: genre best-effort / English-only / test-data leakage / unsigned-commit dev artefacts | [\`DISCLAIMER.md\`](docs/DISCLAIMER.md), [\`EULA.md\`](docs/EULA.md), [\`ToS.md\`](docs/ToS.md), [\`PRIVACY_POLICY.md\`](docs/PRIVACY_POLICY.md) |
| 5 | Workflow Node 20 → 24, action versions refreshed | [\`deploy-pages.yml\`](.github/workflows/deploy-pages.yml) |
| 6 | \`notes.txt\` ignored (was matched only by singular \`[Nn]ote.txt\`) | [\`.gitignore\`](.gitignore) |

## Detail

### Date sort

\`parseReleaseDate(\"22 Aug, 2012\") → 1345593600000\` via \`Date.parse\` with a \`/^\d{4}$/\` fallback for year-only entries. Unparseable / \"Coming Soon\" / \"TBA\" → \`-Infinity\`, so they cluster at the asc-end and stay out of the way of real data on desc.

### Hamburger nav

\`Sidebar\` refactored into a shared \`SidebarBody\` + a desktop \`Sidebar\` wrapper + a new \`MobileSidebar\` that mounts a Radix Dialog as a left-sliding sheet. Topbar adds a \`Menu\` button visible only below \`lg\`. Tapping a nav entry inside the drawer auto-closes it via a \`useLocation\` effect.

### About expansion

Three new cards on top of the existing \"Repository / Maintained by / Report / Stack\" cards:

- **Heads-up** — the four accuracy caveats from \`notes.txt\`.
- **AI disclosure** — names Grok (v1) + Claude (v2+); confirms no runtime LLM calls from the user's browser.
- **Legal & license** — direct links to MIT + DISCLAIMER + ToS + EULA + PRIVACY + ACKNOWLEDGEMENTs + Contact.

The Stack list now shows SPDX licence badges per dep (e.g. \`MIT\`, \`Apache-2.0\`, \`LGPL-3.0\`, \`BSD-3-Clause\`, \`ISC\`), each linking to that project's actual LICENSE file.

### Legal docs

Tightened wording across DISCLAIMER / EULA / ToS / PRIVACY while keeping the maintainer's casual voice. Each doc now explicitly enumerates the accuracy caveats, names the third-party trademarks (Steam / Akamai / GitHub), and references the AI-assistance status. PRIVACY_POLICY now lists exactly the four third-party endpoints touched at runtime (\`raw.githubusercontent.com\`, \`api.github.com\`, \`shared.akamai.steamstatic.com\`, \`avatars.githubusercontent.com\`) and links each one's own privacy policy.

### Workflows

\`actions/checkout@v4 → v5\`, \`actions/setup-node@v4 → v5\` (node-version 20 → 24), \`actions/upload-pages-artifact@v3 → v4\`, \`actions/deploy-pages@v4 → v5\`. Eliminates the \"Node.js 20 actions are deprecated\" annotation that's been on every deploy run.

### \`notes.txt\`

The local working notes from the maintainer. Existing rule only matched \`[Nn]ote.txt\` (singular). Added \`[Nn]otes.txt\` / \`[Nn]otes.md\`.

## Test plan

- [x] tsc --noEmit clean
- [x] vite build 4.87 s
- [ ] After merge: Games table → click \"Released\" header → asc / desc sort by year, not alphabetic.
- [ ] On mobile or at \< lg width: hamburger button in topbar opens the sidebar; tapping a nav entry navigates and closes the drawer.
- [ ] /about: scroll through, verify all 7 sections render, all SPDX badges link to real LICENSE files.
- [ ] /docs/DISCLAIMER.md (on GitHub) and the others render the new content cleanly.
- [ ] Workflow run after merge — no \"Node.js 20 deprecated\" annotation; deploy still succeeds on Node 24.

## Skipped from the notes

- **Build desktop app** (Tauri, fixed-size, no-maximize, always-latest) — deferred. Notes say \"Khi viết build ứng dụng…\" so this is forward-looking, not for now.
- **Per-component license info** — partially done (per-dep SPDX badges). If you want a full \`THIRD_PARTY_LICENSES.txt\` with full text included, that's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)