### PR TITLE
Phase 10.1: regenerate minisign updater keypair (no-password)

### DIFF
--- a/web/src-tauri/.gitignore
+++ b/web/src-tauri/.gitignore
@@ -2,3 +2,10 @@
 target/
 gen/
 WixTools/
+
+# Minisign signing keys — stored under ~/.tauri/, never in repo. This guard
+# catches accidental drops into src-tauri/ during development.
+*.key
+*.key.pub
+f2p-tracker
+f2p-tracker.pub

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
       "endpoints": [
         "https://github.com/poli0981/free-steam-games-list/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY2RTM2NTA0RUFFOEUzQTIKUldTaTQranFCR1hqOWpBOTNTYWFCQVB0azJVdWE2aUQwNExScVphWVVmYmROOTltd0plT3B1bVgK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlGMzk3NzRBRTU0NTNDNTMKUldSVFBFWGxTbmM1bjV6VVU1Um40cXBwVncvOTJzWGtKZXpRM0J3QnJneWFFcUI2QzhJNjVnajQK"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix for the `desktop-v1.0.0` release-desktop workflow failure:

```
failed to decode secret key: incorrect updater private key password:
                              Missing comment in secret key
```

The previous keypair's password was lost, so the GH secret could no longer decrypt the key. Re-keyed with `tauri signer generate --ci -p ""` (no password). New pubkey baked into `tauri.conf.json`; secrets `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` rotated via `gh secret set` (password = empty string).

`src-tauri/.gitignore` extended to cover `*.key` / `f2p-tracker{,.pub}` as a guard — keys live under `~/.tauri/`, never in repo.

## Test plan

- [ ] After merge → re-tag `desktop-v1.0.0` at new HEAD → workflow runs.
- [ ] Build artefacts (`.msi`, `.exe`, `.dmg`, `.AppImage`, `.deb`) produce successfully.
- [ ] Sign-updater step passes — `latest.json` + `*.sig` files attached to draft GH Release.
- [ ] Manual install of one build on Windows or Linux still launches the 1400×900 window.

## Risk

Auto-update from any pre-existing installed copy (none today since Phase 9/10 runs both failed before publishing) breaks because the public key changed. New installs starting `desktop-v1.0.0` (Phase 10.1 build) onward verify against the new key correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)