### PR TITLE
ci: scope notify wrappers to specific source workflows

### DIFF
--- a/.github/workflows/notify-ci-failure.yml
+++ b/.github/workflows/notify-ci-failure.yml
@@ -2,7 +2,25 @@ name: Notify CI Failures
 
 on:
   workflow_run:
-    workflows: ["*"]
+    # Listen only to workflows we want failure notifications for. Replaces the
+    # earlier `workflows: ["*"]` catch-all that fired on every completion and
+    # was filtered out by the reusable's `if:` (95%+ skip rate).
+    #
+    # WARNING: these strings must match the `name:` field in each source
+    # workflow's YAML. Renaming a source workflow → update this list, or
+    # notifications silently break.
+    workflows:
+      - "Auto Update JSON Data"
+      - "Generate Markdown Tables"
+      - "Top Online Leaderboard"
+      - "Update Reviews"
+      - "Check Dead Links"
+      - "Purge Unhealthy Games"
+      - "Ingest New Game Links"
+      - "Ingest from Issue"
+      - "Bot Ingest"
+      - "Force Re-fetch All (v2.1 Schema)"
+      - "CodeQL"
     types: [completed]
 
 # REQUIRED: declare permissions matching the reusable workflow's needs.
@@ -13,5 +31,8 @@ permissions:
 
 jobs:
   notify:
+    # Defense-in-depth: only fire on actual failures so the reusable's own
+    # `if:` becomes a no-op rather than a "skipped" run.
+    if: github.event.workflow_run.conclusion == 'failure'
     uses: poli0981/.github/.github/workflows/notify-ci-failure.yml@main
     secrets: inherit

--- a/.github/workflows/notify-deploy.yml
+++ b/.github/workflows/notify-deploy.yml
@@ -2,7 +2,9 @@ name: Notify Deploy Status
 
 on:
   workflow_run:
-    workflows: ["*"]
+    # Only the deploy workflow's name matters here. Renaming "Deploy Web
+    # (GitHub Pages)" → update this list.
+    workflows: ["Deploy Web (GitHub Pages)"]
     types: [completed]
 
 permissions:
@@ -11,5 +13,6 @@ permissions:
 
 jobs:
   notify:
+    if: contains(fromJSON('["success","failure"]'), github.event.workflow_run.conclusion)
     uses: poli0981/.github/.github/workflows/notify-deploy.yml@main
     secrets: inherit

--- a/.github/workflows/notify-release-pipeline.yml
+++ b/.github/workflows/notify-release-pipeline.yml
@@ -2,7 +2,10 @@ name: Notify Release Pipeline
 
 on:
   workflow_run:
-    workflows: ["*"]
+    # Release-related workflows only. Renaming any of these → update list.
+    workflows:
+      - "Release Desktop App"
+      - "Announce Release to Discord"
     types: [completed]
 
 permissions:
@@ -11,5 +14,6 @@ permissions:
 
 jobs:
   notify:
+    if: contains(fromJSON('["success","failure","cancelled"]'), github.event.workflow_run.conclusion)
     uses: poli0981/.github/.github/workflows/notify-release-pipeline.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Stop the 3 notify wrappers (`notify-ci-failure`, `notify-deploy`, `notify-release-pipeline`) from triggering on every workflow completion (`workflows: ["*"]`), then being filtered out by the reusable's job-level `if:` — 95–100% of runs were showing as "skipped".
- Each wrapper now lists exactly the source workflows whose completions matter to it (CI failures, deploy, release).
- Job-level `if:` short-circuits non-matching conclusions so the reusable becomes a no-op rather than a "skipped" run.

## Why
- Cleaner Actions UI history — no more pages of skipped runs to scroll past.
- Lower noise / fewer wasted runner queue slots.
- Easier to spot real failures.

## Risks
- **Renaming a source workflow's `name:` silently breaks notifications.** Each wrapper has a comment warning about the coupling. If we rename "Top Online Leaderboard" → must update the list.
- `notify-ci-failure` will ping for failures on PRs from forks too (e.g., CodeQL fork PR fail). Acceptable for now; can add `&& github.event.workflow_run.event != 'pull_request'` later if noisy.

## Test plan
- [ ] After merge, trigger a `workflow_dispatch` on a workflow NOT in any list (none currently — we covered all relevant ones, so this is a sanity check that we don't regress).
- [ ] Force-fail a workflow in the list (e.g., `top-online.yml` with bad input) → confirm `notify-ci-failure` produces a non-skipped run with `conclusion=success`.
- [ ] Run `gh run list --workflow notify-ci-failure.yml --limit 20 --json conclusion` over a 7-day window after merge → skip rate should drop from 95–100% to <10%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)