### PR TITLE
feat(data): mark dead online games (no players >=14d)

### DIFF
--- a/.github/workflows/bot-ingest.yml
+++ b/.github/workflows/bot-ingest.yml
@@ -23,11 +23,12 @@ on:
 permissions:
   contents: write
 
-# Queue concurrent dispatches instead of running them in parallel — prevents
-# commit conflicts on data/ shards. cancel-in-progress=false so we don't drop
-# legitimate work when the user dispatches twice in quick succession.
+# Share `data-write` group with all other workflows that push to data/ —
+# prevents commit conflicts on shards. cancel-in-progress=false so we don't
+# drop legitimate work.
 concurrency:
-  group: bot-ingest
+  group: data-write
+  cancel-in-progress: false
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/check-dead-links.yml
+++ b/.github/workflows/check-dead-links.yml
@@ -3,6 +3,9 @@ on :
   schedule : [ { cron : '0 4 1,6,11,16,21,26 * *' } ]
   workflow_dispatch :
 permissions : { contents : write }
+concurrency :
+  group : data-write
+  cancel-in-progress : false
 jobs :
   check :
     runs-on : ubuntu-latest

--- a/.github/workflows/ingest-from-issue.yml
+++ b/.github/workflows/ingest-from-issue.yml
@@ -2,6 +2,9 @@ name : Ingest from Issue
 on :
   issues : { types : [ opened ] }
 permissions : { contents : write, issues : write }
+concurrency :
+  group : data-write
+  cancel-in-progress : false
 jobs :
   ingest :
     if : contains(github.event.issue.title, '[add-game]')

--- a/.github/workflows/ingest-new.yml
+++ b/.github/workflows/ingest-new.yml
@@ -3,6 +3,9 @@ on :
   push : { paths : [ 'scripts/temp_info.jsonl' ] }
   workflow_dispatch :
 permissions : { contents : write }
+concurrency :
+  group : data-write
+  cancel-in-progress : false
 jobs :
   ingest :
     runs-on : ubuntu-latest

--- a/.github/workflows/mark-dead-games.yml
+++ b/.github/workflows/mark-dead-games.yml
@@ -1,0 +1,67 @@
+name: Mark Dead Games
+
+on:
+  schedule:
+    # Mon + Thu 04:30 UTC. Runs after Sun/Wed top-online refreshes player
+    # counts, so current_players is at most ~24h old when we read it.
+    - cron: '30 4 * * 1,4'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no write)'
+        type: boolean
+        default: false
+      days:
+        description: 'Threshold in days (default 14)'
+        default: '14'
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: data-write
+  cancel-in-progress: false
+
+jobs:
+  mark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: scripts/requirements.txt
+
+      - run: pip install -r scripts/requirements.txt
+
+      - name: Mark dead games
+        env:
+          DEAD_GAME_DAYS: ${{ inputs.days || '14' }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python scripts/mark_dead_games.py --dry-run
+          else
+            python scripts/mark_dead_games.py
+          fi
+
+      - name: Commit changes
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/ scripts/dead_games.log
+          if git diff --cached --quiet; then
+            echo "No changes."
+          else
+            git commit -m "chore(data): mark dead games"
+            git push
+          fi
+
+      - name: Trigger markdown rebuild
+        if: ${{ inputs.dry_run != true && success() }}
+        run: gh workflow run "Generate Markdown Tables"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-ci-failure.yml
+++ b/.github/workflows/notify-ci-failure.yml
@@ -20,6 +20,7 @@ on:
       - "Ingest from Issue"
       - "Bot Ingest"
       - "Force Re-fetch All (v2.1 Schema)"
+      - "Mark Dead Games"
       - "CodeQL"
     types: [completed]
 

--- a/.github/workflows/purge-unhealthy.yml
+++ b/.github/workflows/purge-unhealthy.yml
@@ -3,6 +3,9 @@ on :
   schedule : [ { cron : '0 5 * * 1' } ]
   workflow_dispatch :
 permissions : { contents : write }
+concurrency :
+  group : data-write
+  cancel-in-progress : false
 jobs :
   purge :
     runs-on : ubuntu-latest

--- a/.github/workflows/refetch-all.yml
+++ b/.github/workflows/refetch-all.yml
@@ -15,6 +15,10 @@ on :
 permissions :
   contents : write
 
+concurrency :
+  group : data-write
+  cancel-in-progress : false
+
 jobs :
   refetch :
     if : ${{ github.event.inputs.confirm == 'yes' }}

--- a/.github/workflows/top-online.yml
+++ b/.github/workflows/top-online.yml
@@ -3,6 +3,9 @@ on:
   schedule: [{cron: '0 3 * * 0,3,5'}]
   workflow_dispatch:
 permissions: {contents: write}
+concurrency:
+  group: data-write
+  cancel-in-progress: false
 jobs:
   leaderboard:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-daily.yml
+++ b/.github/workflows/update-daily.yml
@@ -3,6 +3,9 @@ on:
   workflow_run: {workflows: ['Auto Update JSON Data'], types: [completed]}
   workflow_dispatch:
 permissions: {contents: write}
+concurrency:
+  group: data-write
+  cancel-in-progress: false
 jobs:
   generate:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/update-json.yml
+++ b/.github/workflows/update-json.yml
@@ -3,6 +3,9 @@ on:
   schedule: [{cron: '0 0 * * *'}]
   workflow_dispatch:
 permissions: {contents: write}
+concurrency:
+  group: data-write
+  cancel-in-progress: false
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-reviews.yml
+++ b/.github/workflows/update-reviews.yml
@@ -3,6 +3,9 @@ on :
   schedule : [ { cron : '0 6 */2 * *' } ]
   workflow_dispatch :
 permissions : { contents : write }
+concurrency :
+  group : data-write
+  cancel-in-progress : false
 jobs :
   reviews :
     runs-on : ubuntu-latest

--- a/scripts/check_dead_links.py
+++ b/scripts/check_dead_links.py
@@ -4,7 +4,7 @@ import sys, os, random, time
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from datetime import datetime, timezone
 from core.constants import DEAD_LINKS_LOG, BATCH_SIZE, BATCH_PAUSE_MIN, BATCH_PAUSE_MAX
-from core.data_store import load_main, save_main, extract_appid, now_iso
+from core.data_store import load_main, save_main, extract_appid, now_iso, append_note_idempotent
 from core.steam_client import get_client
 
 def main():
@@ -24,7 +24,7 @@ def main():
             if code in (404, 410):
                 print(f"  [{i+1}/{total}] 💀 {name} ({code})")
                 g["status"] = "delisted"
-                g["notes"] = (g.get("notes","") + f" 💀 Delisted ({code})").strip()
+                append_note_idempotent(g, "💀 Delisted", f"💀 Delisted ({code})")
                 g["last_updated"] = now_iso()
                 dead.append({"name": name, "appid": appid, "code": code})
             else:

--- a/scripts/core/data_store.py
+++ b/scripts/core/data_store.py
@@ -184,7 +184,24 @@ _SKELETON_TEMPLATE = {
     "drm_notes": "-",
     "notes": "", "safe": "?",
     "status": "active", "last_updated": "", "added_at": "",
+    # v2.3 dead-game detection
+    "is_dead": False,
+    "zero_player_since": "",
 }
+
+
+def append_note_idempotent(game: dict, marker: str, full_note: str) -> bool:
+    """Append `full_note` to game['notes'] only if `marker` isn't already present.
+
+    Used by check_dead_links and mark_dead_games to avoid duplicating system
+    notes when a workflow re-runs over an already-marked game. Returns True
+    when the note was actually changed.
+    """
+    notes = game.get("notes", "") or ""
+    if marker in notes:
+        return False
+    game["notes"] = (notes + " " + full_note).strip() if notes else full_note
+    return True
 
 
 def make_skeleton(link: str) -> dict:

--- a/scripts/mark_dead_games.py
+++ b/scripts/mark_dead_games.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Mark online games >1 year old with current_players=0 for ≥N days as dead.
+
+Logic:
+  - Only games with status="active" and type_game="online" are considered.
+    Single-player games legitimately have 0 concurrent players.
+  - Only games released >1 year ago — avoids false positives for new games
+    in their early-adoption phase.
+  - First time we observe 0 players → set zero_player_since timestamp.
+  - Once `now - zero_player_since >= DEAD_GAME_DAYS`, set is_dead=True and
+    append "💀 Dead game" to notes (idempotent).
+  - When players come back, clear zero_player_since (but is_dead persists
+    until manually unset — recovery is rare and human-judgement worthy).
+
+Usage:
+  python scripts/mark_dead_games.py [--dry-run] [--days N]
+
+Env:
+  DEAD_GAME_DAYS  default threshold (overridden by --days)
+"""
+import sys, os, argparse, re
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from datetime import datetime, timedelta, timezone
+from core.data_store import (
+    load_main, save_main, now_iso, append_note_idempotent,
+)
+
+DEAD_LOG = "scripts/dead_games.log"
+DEFAULT_DAYS = int(os.environ.get("DEAD_GAME_DAYS", "14"))
+DEAD_MARKER = "💀 Dead game"
+
+# Steam release_date formats: "22 Aug, 2012", "Dec 19, 2025", "2025",
+# "Coming Soon", "TBA", "" — must handle all gracefully.
+_DATE_FORMATS = ["%d %b, %Y", "%b %d, %Y", "%Y-%m-%d", "%Y"]
+_PLACEHOLDERS = {"coming soon", "tba", "to be announced", "n/a", ""}
+
+
+def parse_release(s: str):
+    if not s or s.strip().lower() in _PLACEHOLDERS:
+        return None
+    s = s.strip()
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def parse_players(s) -> int:
+    if s is None:
+        return 0
+    if isinstance(s, (int, float)):
+        return int(s)
+    digits = re.sub(r"[^\d]", "", str(s))
+    return int(digits) if digits else 0
+
+
+def parse_iso(s: str):
+    if not s:
+        return None
+    try:
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print decisions without writing")
+    ap.add_argument("--days", type=int, default=DEFAULT_DAYS,
+                    help=f"Threshold in days (default {DEFAULT_DAYS})")
+    args = ap.parse_args()
+
+    games = load_main()
+    now = datetime.now(timezone.utc)
+    one_year_ago = now - timedelta(days=365)
+    threshold = timedelta(days=args.days)
+
+    started, marked, cleared, skipped = [], [], [], 0
+
+    for g in games:
+        if g.get("status") != "active" or g.get("type_game") != "online":
+            skipped += 1
+            continue
+        rel = parse_release(g.get("release_date", ""))
+        if rel is None or rel > one_year_ago:
+            # New / unparseable release date → reset streak, leave alone.
+            if g.get("zero_player_since"):
+                g["zero_player_since"] = ""
+            skipped += 1
+            continue
+
+        players = parse_players(g.get("current_players"))
+
+        if players > 0:
+            if g.get("zero_player_since"):
+                g["zero_player_since"] = ""
+                cleared.append(g.get("name", "?"))
+            continue
+
+        # players == 0
+        since_dt = parse_iso(g.get("zero_player_since", ""))
+        if since_dt is None:
+            g["zero_player_since"] = now_iso()
+            g["last_updated"] = now_iso()
+            started.append(g.get("name", "?"))
+            continue
+
+        if now - since_dt < threshold:
+            continue
+
+        if not g.get("is_dead"):
+            note = f"{DEAD_MARKER} (no players ≥{args.days}d)"
+            if append_note_idempotent(g, DEAD_MARKER, note):
+                g["is_dead"] = True
+                g["last_updated"] = now_iso()
+                marked.append(g.get("name", "?"))
+
+    print(
+        f"Scanned {len(games)} | skipped {skipped} | "
+        f"started-streak {len(started)} | cleared-streak {len(cleared)} | "
+        f"marked-dead {len(marked)}"
+    )
+    for n in marked:
+        print(f"  💀 {n}")
+
+    if args.dry_run:
+        print("(dry-run — not writing)")
+        return
+
+    save_main(games)
+
+    if marked:
+        ts = now.strftime("%Y-%m-%d %H:%M UTC")
+        with open(DEAD_LOG, "a", encoding="utf-8") as f:
+            f.write(f"\n── {ts} (threshold {args.days}d) ──\n")
+            for n in marked:
+                f.write(f"  💀 {n}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/components/games/GamesTable.tsx
+++ b/web/src/components/games/GamesTable.tsx
@@ -94,7 +94,12 @@ const COLS: ColDef[] = [
     width: 280,
     sortable: true,
     sortValue: (g) => g.name?.toLowerCase() ?? "",
-    render: (g) => <span className="font-medium">{g.name || "—"}</span>,
+    render: (g) => (
+      <span className="font-medium">
+        {g.is_dead && <span title="Dead game (no players)" className="mr-1">💀</span>}
+        {g.name || "—"}
+      </span>
+    ),
   },
   {
     key: "genre",
@@ -239,6 +244,7 @@ export function GamesTable({ records, onRowOpen }: Props) {
   const typeGame = useFilters((s) => s.type_game);
   const platform = useFilters((s) => s.platform);
   const status = useFilters((s) => s.status);
+  const hideDead = useFilters((s) => s.hideDead);
   const sortKey = useFilters((s) => s.sortKey);
   const sortDir = useFilters((s) => s.sortDir);
   const setSort = useFilters((s) => s.setSort);
@@ -256,7 +262,7 @@ export function GamesTable({ records, onRowOpen }: Props) {
   // Reset page when filters or page size change.
   useEffect(() => {
     setPage(1);
-  }, [search, genre, typeGame, platform, status, pageSize]);
+  }, [search, genre, typeGame, platform, status, hideDead, pageSize]);
 
   const fuse = useMemo(
     () =>
@@ -278,8 +284,9 @@ export function GamesTable({ records, onRowOpen }: Props) {
     if (platform)
       out = out.filter((g) => (g.platforms ?? []).includes(platform));
     if (status) out = out.filter((g) => g.status === status);
+    if (hideDead) out = out.filter((g) => !g.is_dead);
     return out;
-  }, [records, search, genre, typeGame, platform, status, fuse]);
+  }, [records, search, genre, typeGame, platform, status, hideDead, fuse]);
 
   const sorted = useMemo(() => {
     if (!sortKey || !sortDir) return filtered;

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -87,6 +87,7 @@
     "filterAllTypes": "All types",
     "filterAllPlatforms": "All platforms",
     "filterAllStatus": "All status",
+    "hideDead": "Hide dead",
     "selectAllVisible": "Select all visible ({{count}})",
     "bulkEdit": "Bulk edit",
     "bulkDelete": "Delete",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -87,6 +87,7 @@
     "filterAllTypes": "Mọi loại",
     "filterAllPlatforms": "Mọi nền tảng",
     "filterAllStatus": "Mọi trạng thái",
+    "hideDead": "Ẩn dead",
     "selectAllVisible": "Chọn tất cả ({{count}})",
     "bulkEdit": "Sửa hàng loạt",
     "bulkDelete": "Xoá",

--- a/web/src/lib/schema.ts
+++ b/web/src/lib/schema.ts
@@ -117,6 +117,9 @@ export interface GameRecord {
   status: GameStatus;
   last_updated: string;
   added_at: string;
+  // v2.3 dead-game detection
+  is_dead: boolean;
+  zero_player_since: string;
 }
 
 export interface ShardManifestEntry {
@@ -159,6 +162,8 @@ export const SKELETON_TEMPLATE: GameRecord = {
   status: "active",
   last_updated: "",
   added_at: "",
+  is_dead: false,
+  zero_player_since: "",
 };
 
 export function isManualField(key: string): key is ManualField {

--- a/web/src/pages/Games.tsx
+++ b/web/src/pages/Games.tsx
@@ -23,6 +23,8 @@ export function GamesPage() {
   const setPlatform = useFilters((s) => s.setPlatform);
   const status = useFilters((s) => s.status);
   const setStatus = useFilters((s) => s.setStatus);
+  const hideDead = useFilters((s) => s.hideDead);
+  const setHideDead = useFilters((s) => s.setHideDead);
   const reset = useFilters((s) => s.reset);
 
   const facets = useMemo(() => {
@@ -45,7 +47,7 @@ export function GamesPage() {
   if (q.error) return <ErrorState error={q.error} />;
   if (!q.data) return null;
 
-  const hasFilter = genre || typeGame || platform || status;
+  const hasFilter = genre || typeGame || platform || status || hideDead;
   const linkedGame = appid
     ? (() => {
         const idx = q.data.appidIndex.get(appid);
@@ -114,6 +116,16 @@ export function GamesPage() {
           <option value="delisted">{t("common.delisted")}</option>
         </select>
 
+        <label className="flex h-8 select-none items-center gap-1.5 rounded-md border bg-background px-2 text-sm">
+          <input
+            type="checkbox"
+            checked={hideDead}
+            onChange={(e) => setHideDead(e.target.checked)}
+            className="h-3.5 w-3.5 rounded border-input bg-transparent accent-primary"
+          />
+          {t("games.hideDead")}
+        </label>
+
         {hasFilter && (
           <Button variant="ghost" size="sm" onClick={reset}>
             <X className="mr-1 h-3 w-3" /> {t("common.clear")}
@@ -125,6 +137,7 @@ export function GamesPage() {
           {typeGame && <Badge variant="default">type: {typeGame}</Badge>}
           {platform && <Badge variant="default">platform: {platform}</Badge>}
           {status && <Badge variant="default">status: {status}</Badge>}
+          {hideDead && <Badge variant="default">💀 hidden</Badge>}
         </div>
       </div>
 

--- a/web/src/stores/filters.ts
+++ b/web/src/stores/filters.ts
@@ -12,6 +12,7 @@ export interface FilterState {
   safe: string | null;
   status: "active" | "delisted" | null;
   hasAntiCheat: boolean | null;
+  hideDead: boolean;
   sortKey: string | null;
   sortDir: SortDir;
   pageSize: PageSize;
@@ -23,6 +24,7 @@ export interface FilterState {
   setSafe: (s: string | null) => void;
   setStatus: (s: "active" | "delisted" | null) => void;
   setHasAntiCheat: (b: boolean | null) => void;
+  setHideDead: (b: boolean) => void;
   setSort: (key: string | null, dir: SortDir) => void;
   setPageSize: (size: PageSize) => void;
   toggleSelect: (appid: string) => void;
@@ -39,6 +41,7 @@ const initial = {
   safe: null,
   status: null,
   hasAntiCheat: null,
+  hideDead: false,
   sortKey: null,
   sortDir: null as SortDir,
   pageSize: 100 as PageSize,
@@ -54,6 +57,7 @@ export const useFilters = create<FilterState>((set) => ({
   setSafe: (safe) => set({ safe }),
   setStatus: (status) => set({ status }),
   setHasAntiCheat: (hasAntiCheat) => set({ hasAntiCheat }),
+  setHideDead: (hideDead) => set({ hideDead }),
   setSort: (sortKey, sortDir) => set({ sortKey, sortDir }),
   setPageSize: (pageSize) => set({ pageSize }),
   toggleSelect: (appid) =>


### PR DESCRIPTION
## Summary
- New cron 2x/week that flags online games released >1 year ago with `current_players == 0` across consecutive runs.
- After 14 days of zero-player observations, the game gets `is_dead: true` and "💀 Dead game" appended to notes (idempotent).
- Web app gains a "Hide dead" filter toggle and a 💀 prefix on dead rows.
- All data-mutating workflows share a `concurrency: data-write` group to prevent races on shard pushes.

## Why
- `check_dead_links.py` already catches 404/410. This catches the other failure mode: link still works but nobody plays it anymore (server shutdown, abandoned MMOs, etc.).
- Drives a more accurate Top Online leaderboard once dead games can be hidden.

## Approach (key decisions)
- **State model**: `zero_player_since` ISO timestamp, not a streak counter — robust against schedule drift, missed runs, manual dispatches.
- **Threshold**: 14 days (~4 runs at 2x/week). Configurable via `DEAD_GAME_DAYS` env or `--days` CLI.
- **Scope**: only `status="active"` AND `type_game="online"` AND release_date parseable AND >1 year old. Single-player games are skipped (legitimate 0 players).
- **Mark mechanism**: additive `is_dead: bool` + note. Status stays "active" — doesn't break the existing enum or top-online filter; UI gets a separate toggle.
- **Idempotent notes**: new `append_note_idempotent()` helper in `data_store.py`; also retrofitted onto `check_dead_links.py` to fix duplicate "💀 Delisted" accumulation on reruns.

## Files
- **New**: `scripts/mark_dead_games.py`, `.github/workflows/mark-dead-games.yml`.
- **Schema**: `scripts/core/data_store.py` and `web/src/lib/schema.ts` — `is_dead` + `zero_player_since` defaults via SKELETON_TEMPLATE (lazy migration).
- **Web**: filter store + Games page checkbox + GamesTable 💀 prefix + en/vi locales.
- **Concurrency**: 9 workflows updated to share `data-write` group (bot-ingest, update-json, update-daily, top-online, update-reviews, check-dead-links, purge-unhealthy, ingest-new, ingest-from-issue, refetch-all, mark-dead-games).
- `notify-ci-failure.yml` list extended with "Mark Dead Games".

## Risks
- **Steam release_date parsing**: handles "22 Aug, 2012", "Dec 19, 2025", "2025", "Coming Soon", "TBA", "N/A", and empty. Unparseable = treated as new (skipped, no false positive).
- **First run won't mark anything** — only sets `zero_player_since`. By design; protects against threshold=0 surprises after deploy.
- **Schema sync**: Python and TS templates must stay aligned on the two new field names. Verified: TS migrate_record loops over SKELETON_TEMPLATE so old records auto-default.
- **Concurrency unification might queue runs**: `cancel-in-progress: false` ensures no work is dropped; cron schedules barely overlap in practice.

## Test plan
- [x] `python -m py_compile` on all new + edited Python — pass.
- [x] All workflow YAML parses — pass.
- [x] `npm run typecheck && npm run build` — pass.
- [x] `python scripts/mark_dead_games.py --dry-run --days 0` against current data: scanned 1262, skipped 1140, started-streak 15, marked-dead 0. Logic confirmed.
- [ ] After merge, dispatch via `gh workflow run "Mark Dead Games" -f dry_run=true` → inspect logs.
- [ ] After ~14 days of cron runs, check `scripts/dead_games.log` for entries.
- [ ] Web app: load → filter "Hide dead" toggle works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)