### PR TITLE
v3.2.0: SEO + Donate + auto-Discussion + Health bucket + dev docs (8 features)

### DIFF
--- a/.github/workflows/announce-release-discussion.yml
+++ b/.github/workflows/announce-release-discussion.yml
@@ -1,0 +1,168 @@
+name: Announce Release as Discussion
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to announce"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  discussions: write
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release + create Discussion
+        uses: actions/github-script@v8
+        env:
+          # Slug of the discussion category to post into. The category must
+          # already exist on the repo (Settings → General → Features →
+          # Discussions). If the slug is missing, the job falls back to the
+          # first available category and logs a warning.
+          PRIMARY_CATEGORY_SLUG: announcements
+          FALLBACK_CATEGORY_SLUG: general
+          # Truncate the release body to keep the discussion readable.
+          BODY_CHAR_LIMIT: "3000"
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const isDispatch = context.eventName === 'workflow_dispatch';
+            const tag = isDispatch
+              ? context.payload.inputs.tag
+              : context.payload.release.tag_name;
+
+            if (!tag) {
+              core.setFailed('No tag resolved from event payload.');
+              return;
+            }
+
+            // Pull release metadata (workflow_dispatch path doesn't include
+            // a release object, so use REST).
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag,
+            });
+
+            const releaseUrl = release.html_url;
+            const releaseName = release.name || tag;
+            const isDesktop = tag.startsWith('desktop-v');
+            const titlePrefix = isDesktop ? 'Desktop' : 'Repo';
+            const title = `[${titlePrefix} ${tag}] ${releaseName}`;
+
+            // Truncate body to keep the discussion light.
+            const limit = parseInt(process.env.BODY_CHAR_LIMIT, 10);
+            let bodyText = release.body || '*(No release notes provided.)*';
+            if (bodyText.length > limit) {
+              bodyText =
+                bodyText.slice(0, limit).trimEnd() +
+                `\n\n…\n\n*(Truncated. Read the full release notes on the [Release page](${releaseUrl}).)*`;
+            }
+
+            const body = [
+              `**Release tag:** \`${tag}\``,
+              `**Release page:** ${releaseUrl}`,
+              `**Published at:** ${release.published_at || release.created_at}`,
+              isDesktop
+                ? '**Platform builds:** Windows `.msi` · macOS `.dmg` · Linux `.AppImage` / `.deb` (auto-update via signed minisign).'
+                : '',
+              '',
+              '---',
+              '',
+              bodyText,
+              '',
+              '---',
+              '',
+              '*(Auto-posted by `.github/workflows/announce-release-discussion.yml`. Reply with feedback, install issues, or feature requests — full bug reports still go through the [issue templates](../../issues/new/choose).)*',
+            ]
+              .filter(Boolean)
+              .join('\n');
+
+            // GraphQL: resolve repo ID + discussion category list.
+            const repoQuery = `
+              query($owner: String!, $repo: String!) {
+                repository(owner: $owner, name: $repo) {
+                  id
+                  discussionCategories(first: 25) {
+                    nodes { id name slug }
+                  }
+                }
+              }
+            `;
+            const repoData = await github.graphql(repoQuery, { owner, repo });
+            const repoId = repoData.repository.id;
+            const categories = repoData.repository.discussionCategories.nodes;
+
+            const primary = process.env.PRIMARY_CATEGORY_SLUG;
+            const fallback = process.env.FALLBACK_CATEGORY_SLUG;
+            let category = categories.find((c) => c.slug === primary);
+            if (!category) {
+              category = categories.find((c) => c.slug === fallback);
+              if (category) {
+                core.warning(
+                  `Category '${primary}' not found — falling back to '${category.slug}'. ` +
+                    `Create an 'Announcements' category to silence this warning.`,
+                );
+              }
+            }
+            if (!category) {
+              category = categories[0];
+              core.warning(
+                `Neither '${primary}' nor '${fallback}' categories exist — using first available: '${category?.slug}'.`,
+              );
+            }
+            if (!category) {
+              core.setFailed('No discussion categories exist on this repo. Enable Discussions first.');
+              return;
+            }
+
+            // Idempotency: search for an existing discussion with the same title.
+            const searchQuery = `
+              query($q: String!) {
+                search(type: DISCUSSION, query: $q, first: 5) {
+                  nodes {
+                    ... on Discussion { id title url }
+                  }
+                }
+              }
+            `;
+            const searchString = `repo:${owner}/${repo} in:title "${title}"`;
+            const searchResult = await github.graphql(searchQuery, { q: searchString });
+            const existing = searchResult.search.nodes.find((n) => n.title === title);
+            if (existing) {
+              core.notice(`Discussion already exists: ${existing.url} — skipping create.`);
+              core.setOutput('discussion_url', existing.url);
+              core.setOutput('skipped', 'true');
+              return;
+            }
+
+            // Create the discussion.
+            const createMutation = `
+              mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+                createDiscussion(input: {
+                  repositoryId: $repositoryId,
+                  categoryId: $categoryId,
+                  title: $title,
+                  body: $body,
+                }) {
+                  discussion { id url }
+                }
+              }
+            `;
+            const created = await github.graphql(createMutation, {
+              repositoryId: repoId,
+              categoryId: category.id,
+              title,
+              body,
+            });
+            const url = created.createDiscussion.discussion.url;
+            core.notice(`Discussion created: ${url} (category: ${category.slug})`);
+            core.setOutput('discussion_url', url);
+            core.setOutput('skipped', 'false');

--- a/.github/workflows/top-offline.yml
+++ b/.github/workflows/top-offline.yml
@@ -1,0 +1,20 @@
+name: Top Offline Leaderboard
+on:
+  # Bi-weekly: 1st and 15th of every month at 05:00 UTC. Cron does not
+  # truly support "every 14 days"; this is the closest approximation.
+  schedule: [{cron: '0 5 1,15 * *'}]
+  workflow_dispatch:
+permissions: {contents: write}
+concurrency:
+  group: data-write
+  cancel-in-progress: false
+jobs:
+  leaderboard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: {token: '${{ secrets.GH_TOKEN }}'}
+      - uses: actions/setup-python@v5
+        with: {python-version: '3.12'}
+      - run: chmod +x ./bash/offline.sh && ./bash/offline.sh
+        env: {STEAM_API_KEY: '${{ secrets.STEAM_API_KEY }}'}

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,21 @@ This file lives at the repo root so the author can be found without digging into
 
 QR codes for the Telegram channels live in [`assets/qr/`](assets/qr/).
 
+## Dev info
+
+For people forking the repo or trying to reproduce a build:
+
+| Item            | Value                                                        |
+| --------------- | ------------------------------------------------------------ |
+| GitHub          | [@poli0981](https://github.com/poli0981)                     |
+| IDE             | JetBrains 2026.x — paid lineup (PyCharm, WebStorm, RustRover) |
+| Toolchains      | Python 3.12 · Node.js ≥ 22 · Rust stable · Tauri 2           |
+| Git             | GPG signing on (`commit.gpgsign=true`)                        |
+| Hardware spec   | [`docs/pc_spec.md`](docs/pc_spec.md) (EN) · [`docs/i18n/vi/pc_spec.md`](docs/i18n/vi/pc_spec.md) (VI) |
+| Dev environment | [`docs/dev_env.md`](docs/dev_env.md) (EN) · [`docs/i18n/vi/dev_env.md`](docs/i18n/vi/dev_env.md) (VI) |
+| Desktop build   | [`web/src-tauri/TAURI.md`](web/src-tauri/TAURI.md)            |
+| Test devices    | iPhone 14 Pro · iPhone 13 Pro Max · iOS 26.x (Chrome / Brave / Safari) |
+
 ## Contributors
 
 Anyone who's filed an issue, opened a PR, or used the Add-Games template is implicitly thanked. The full list is whatever GitHub renders on the [contributors page](https://github.com/poli0981/free-steam-games-list/graphs/contributors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.2.0] – 2026-05-11 (The "SEO + Donate + Auto-Discussion + Health Polish + Dev Docs" Edition)
+
+Single-PR bundle (#64) shipping eight features on top of v3.1.0. Web app + desktop bumped from `1.1.0` → `1.2.0`. Repo public-facing version `3.1.0` → `3.2.0`. Tag `v3.2.0` is GPG-signed; companion desktop tag is `desktop-v1.2.0`.
+
+### 🔍 SEO basics
+
+- `web/index.html` — full Open Graph block (`og:type`, `og:title`, `og:description`, `og:url`, `og:image`, `og:site_name`, `og:locale` + alternate), Twitter Card (`summary`), `<link rel="canonical">`, `meta name="author"`, JSON-LD (`WebSite` + `Person` + `SoftwareApplication`).
+- New `web/public/robots.txt` (allow all + sitemap pointer) and `web/public/sitemap.xml` (5 entries: site root, GitHub repo, all-games / top-online / changelog markdown).
+- New hook `web/src/hooks/useDocumentTitle.ts` — sets `document.title` to `<page> · Steam F2P Tracker` and re-runs on language change. Wired into all 18 routes (Dashboard / Games / TopOnline / Health / Activity / Add / About / Donate / Settings / 9 charts).
+- VitePWA already emits `manifest.webmanifest` from `vite.config.ts`; no manual manifest needed.
+
+### 💬 Auto-create GitHub Discussion on release
+
+- New `.github/workflows/announce-release-discussion.yml` — fires on `release: published` (plus `workflow_dispatch` with a `tag` input for re-runs).
+- Implemented via `actions/github-script@v8` + GraphQL `createDiscussion` (REST has no equivalent).
+- Resolves the discussion category by slug — defaults to `Announcements`, falls back to `General` with a logged warning, then to the first available category.
+- **Idempotent**: a GraphQL search runs first; if a discussion with the same title exists, the workflow skips with `core.notice()` and returns the existing URL via output. Re-running `workflow_dispatch` is therefore a no-op.
+- Permissions: `contents: read`, `discussions: write` — both granted by `GITHUB_TOKEN` defaults once Discussions is enabled on the repo.
+
+### 💖 Donate page
+
+- New `web/src/pages/Donate.tsx` route at `/donate` — grid of 5 platform cards (GitHub Sponsors, Ko-fi, Buy Me a Coffee, Patreon, PayPal) sourced from `.github/FUNDING.yml`.
+- Each card has a tinted icon ring, label, short description, and an "Open" button (`target="_blank" rel="noopener noreferrer"`).
+- New nav item in `web/src/components/layout/Sidebar.tsx` SECONDARY group (between About and Settings); `Heart` icon from lucide.
+- Full EN + VI i18n keys under `donate.*` (title / subtitle / cta / footnote + per-platform label & desc).
+
+### 📖 Dev docs
+
+- New `docs/pc_spec.md` (EN) + `docs/i18n/vi/pc_spec.md` (VI) — maintainer hardware spec mirroring `E:\spec.txt` (CPU / GPU / RAM / IDE) plus iPhone test-device list.
+- New `docs/dev_env.md` (EN) + `docs/i18n/vi/dev_env.md` (VI) — IDE map (PyCharm / WebStorm / RustRover 2026.x), toolchain table (Python 3.12 / Node ≥ 22 / Rust stable / Tauri 2), per-area dev workflow (web / Tauri / Python pipeline), Git + GPG conventions, branch + PR flow.
+- New `web/src-tauri/TAURI.md` — desktop build prerequisites (incl. CI's exact `apt-get` line), local + production build commands, signing + auto-update notes, troubleshooting.
+- `AUTHORS.md` — new "Dev info" table (GitHub handle, IDE channel, toolchain versions, link map to all the above).
+- README "Docs" section — links the four new docs.
+
+### 🤖 Telegram bot user-guide pointer
+
+- New `docs/telegram-bot.md` — one-page pointer to the external [`telegram-scraper-bot/docs/USER_GUIDE.md`](https://github.com/poli0981/telegram-scraper-bot/blob/main/docs/USER_GUIDE.md), bot source repo, plus a paragraph each on what the bot does and the whitelist lifecycle.
+- `CONTRIBUTING.md` — section 3 (`@my_skull_bot`) gets a 3-line callout with the user guide link, bot source URL, and the new in-repo summary doc.
+- `web/src/pages/About.tsx` — Maintainer card's privacy note now includes a "Bot user guide & source" sub-card with the same three links.
+
+### 🩺 Health bucket split
+
+- `web/src/pages/Health.tsx` — `gatherIssues()` adds a fifth `IssueGroup`: `OnlineAcUnknown` for games with `type_game === "online"` and `anti_cheat ∈ {"", "-"}`. Previously these games were silently dropped from all categories; now they have a discoverable home.
+- Edge-case fix: the existing "Kernel" filter compared `(r.anti_cheat ?? "-") !== "-"`, missing the empty-string case. Both filters now use a normalised `(r.anti_cheat ?? "").trim()`.
+- `ShieldQuestion` icon (lucide). EN + VI i18n keys: `health.groupOnlineAcUnknown` + `…Desc`.
+
+### 🎮 Steam Desktop direct link
+
+- New helper `web/src/lib/steam-link.ts` — `steamProtocolUrl(appid)` returns `steam://store/<appid>`, `steamWebUrl(appid)` returns the regular HTTPS store URL.
+- `web/src/components/games/GameDetailDrawer.tsx` — single store link replaced by two buttons rendered side-by-side: a primary "Steam Desktop" (`steam://`) and an outline "Web" (`https://`). Tooltip on the desktop button explains the fallback path.
+- Works in both web build (browser shows protocol prompt if Steam is installed, silent fail otherwise — Web button is the safety net) and Tauri build (Tauri 2 allows `steam://` navigation by default; no allow-list change needed).
+- EN + VI i18n: `detail.openOnSteamDesktop`, `detail.openOnSteamDesktopHint`, `detail.openOnSteamWeb`.
+
+### 🛌 Bi-weekly offline-player leaderboard
+
+- New `scripts/top_offline.py` — clones the `top_online.py` shape but filters `_is_offline(g)` (non-empty `type_game ≠ "online"`). Emits `games/top-offline.md` (top 100 single-player F2P concurrents, 10-column format identical to top-online).
+- Calibrated tier thresholds (`_TIERS`) lower than online (offline games rarely break 6-figure concurrents) — `🔥 Mega ≥ 20k`, `⭐ Hot ≥ 5k`, `🟢 Healthy ≥ 1.5k`, `🟡 Stable ≥ 300`, `🟠 Low ≥ 50`, `🔴 Quiet ≥ 10`, `💀 Idle <10`.
+- New `bash/offline.sh` matches the shape of `bash/online.sh` (pip install requests → run script → conditional commit).
+- New `.github/workflows/top-offline.yml` — cron `0 5 1,15 * *` (1st + 15th of each month at 05:00 UTC) plus `workflow_dispatch`. Shares the unified `data-write` concurrency group.
+- Health page (`web/src/pages/Health.tsx`) — new manual trigger button "Top offline" (next to the existing "Top online" trigger).
+- **Bug fix during implementation**: `scripts/core/fetcher.py:update_players_only()` had a hardcoded `type_game == "online"` filter that would have made the offline workflow refresh zero rows. Extended with a `type_filter` kwarg (`"online"` default for backward compat, `"offline"`, or `"all"`); `top_offline.py` passes `type_filter="offline"` (excludes both online and empty/unclassified type).
+
+### 🔢 Versioning
+
+| Surface | Old | New |
+|---|---|---|
+| Repo public-facing | 3.1.0 | **3.2.0** |
+| `web/package.json` | 1.1.0 | **1.2.0** |
+| `web/src-tauri/Cargo.toml` | 1.1.0 | **1.2.0** |
+| `web/src-tauri/tauri.conf.json` | 1.1.0 | **1.2.0** |
+| Git tag (signed) | `v3.1.0` | `v3.2.0` |
+| Desktop tag (signed) | `desktop-v1.1.0` | `desktop-v1.2.0` |
+
+---
+
 ## [v3.1.0] – 2026-05-09 (The "Less CI Noise, Lighter Images, Dead-Game Detection" Edition)
 
 Four PRs landed in this release plus a refresh of the docs and the contributor surface around the new Telegram bot. Web app + desktop app bumped from `1.0.0` → `1.1.0`. Repo public-facing version `3.0.1` → `3.1.0`. Tag `v3.1.0` is GPG-signed; companion desktop tag is `desktop-v1.1.0`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ The web app commits via the Git Data API + GPG signing path. The optimistic-upda
 
 Quick path for users who don't want a GitHub PAT but do want to add games. The bot wraps the same `ingest-new` pipeline behind a Telegram chat.
 
+> 📖 **Full user guide:** [`telegram-scraper-bot/docs/USER_GUIDE.md`](https://github.com/poli0981/telegram-scraper-bot/blob/main/docs/USER_GUIDE.md) — command reference, edge cases, troubleshooting.
+> 🔗 **Bot source repo:** <https://github.com/poli0981/telegram-scraper-bot>
+> 📄 **In-repo summary:** [`docs/telegram-bot.md`](docs/telegram-bot.md) — one-page pointer + privacy notes.
+
 > **One-time setup (whitelist your Telegram `user_id`)**
 >
 > 1. **Find your Telegram `user_id`.** Easiest way: DM `@userinfobot` on Telegram and it replies with your numeric `user_id`. Other options: `@RawDataBot`, `@getmyid_bot`, or any "what's my Telegram ID" bot of your choice.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.1.0-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.2.0-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ scripts/
 | **Bot Ingest**        | Telegram bot dispatch            | Add games via `@my_skull_bot` (whitelist required)        |
 | **Deploy Web**        | On `web/**` or `data/**` change  | Build + deploy SPA to GitHub Pages                        |
 | **Release Desktop**   | On `desktop-v*` tag              | Matrix-build Tauri installers (Win/Mac/Linux) → Releases |
+| **Top Offline**       | 1st + 15th of month 05:00 UTC    | Bi-weekly leaderboard for single-player F2P concurrents   |
+| **Announce Discussion** | On release `published`         | Auto-create a GitHub Discussion in `Announcements` per release |
 
 ### Contribute
 
@@ -222,6 +224,10 @@ Unemployed, introvert max level, dropped out uni year 3, mooching off family. Ne
 - [AUTHORS](AUTHORS.md) — maintainer + canonical handle map + AI-assistant disclosure.
 - [CHANGELOG](CHANGELOG.md) — what changed in each version.
 - [CONTRIBUTING](CONTRIBUTING.md) — issue templates, web-app sign-in, Telegram bot flow, extension, manual fork.
+- [PC spec](docs/pc_spec.md) ([VI](docs/i18n/vi/pc_spec.md)) — maintainer's dev hardware + test devices.
+- [Dev environment](docs/dev_env.md) ([VI](docs/i18n/vi/dev_env.md)) — IDE, toolchains (Python 3.12 / Node ≥ 22 / Rust stable / Tauri 2), workflow.
+- [Tauri build](web/src-tauri/TAURI.md) — desktop build prerequisites + signing + auto-update.
+- [Telegram bot](docs/telegram-bot.md) — pointer to the external bot user guide + how it integrates with this repo.
 - [DISCLAIMER](docs/DISCLAIMER.md) — accuracy caveats, no-warranty, the broke-maintainer note.
 - [Terms of Use](docs/ToS.md) — usage agreement, contributions, governing law, **rules for sharing your Telegram `user_id`**.
 - [EULA](docs/EULA.md) — supplemental to the MIT licence.

--- a/bash/offline.sh
+++ b/bash/offline.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+pip install --quiet requests
+python scripts/top_offline.py
+git config --global user.name 'github-actions[bot]'
+git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+git add . && git diff --staged --quiet && echo "No changes" || (git commit -m "Top offline [$(date +'%Y-%m-%d %H:%M')]" && git push)

--- a/docs/dev_env.md
+++ b/docs/dev_env.md
@@ -1,0 +1,87 @@
+# Developer environment
+
+IDE, language toolchains, and the day-to-day workflow used to develop this repo. Mirrored in Vietnamese at [`i18n/vi/dev_env.md`](i18n/vi/dev_env.md).
+
+## IDEs
+
+| Tool       | Used for                                                           |
+| ---------- | ------------------------------------------------------------------ |
+| PyCharm    | `scripts/` Python pipeline (data fetcher, scraper, generator)      |
+| WebStorm   | `web/src/` React + TypeScript + Vite                                |
+| RustRover  | `web/src-tauri/` Tauri 2 desktop wrapper (Rust)                    |
+
+JetBrains lineup, paid version, channel **2026.x**. Any equivalent editor (VS Code, Neovim, etc.) works — the repo is editor-agnostic.
+
+## Toolchains
+
+| Tool        | Version             | Notes                                         |
+| ----------- | ------------------- | --------------------------------------------- |
+| Python      | 3.12                | `scripts/` pipeline + Steam client            |
+| Node.js     | ≥ 22 (LTS)          | web build, Tauri build pipeline               |
+| Rust        | stable (via rustup) | Tauri runtime                                 |
+| npm         | bundled with Node   | `web/package-lock.json` is the source of truth |
+| Git         | recent              | GPG signing on (`commit.gpgsign=true`)         |
+| Tauri CLI   | 2.x                 | invoked via `npm run tauri ...`                |
+
+The CI workflows in [`.github/workflows/`](../.github/workflows) pin these versions explicitly. See [`release-desktop.yml`](../.github/workflows/release-desktop.yml) for the desktop build matrix and [`deploy-pages.yml`](../.github/workflows/deploy-pages.yml) for the web deploy.
+
+## Dev workflow
+
+### Web app
+
+```bash
+cd web
+npm ci                   # one-time install
+npm run dev              # http://localhost:5173 (Vite)
+npm run typecheck        # strict TS
+npm run build            # production bundle into web/dist
+npm run preview          # serve the built bundle
+```
+
+Both `typecheck` and `build` must pass before opening a PR — there is no formal test suite for the React side, type-strictness is the safety net.
+
+### Tauri desktop
+
+```bash
+cd web
+npm run tauri dev        # dev build with hot reload, Rust + WebKit
+npm run tauri build      # release binary into web/src-tauri/target/release/bundle
+```
+
+Platform prerequisites + signing notes live in [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md).
+
+### Python pipeline
+
+```bash
+cd scripts
+python -m pip install -r requirements.txt   # if a requirements file exists
+python ingest_new.py                         # process scripts/temp_info.jsonl
+python update_data.py                        # daily full refresh
+python top_online.py                         # rebuild games/top-online.md
+```
+
+There is no formal unit-test suite — the pipeline is intentionally low-ceremony. Lint with `ruff` if you have it; otherwise rely on review.
+
+### Git + GPG
+
+- **Always** sign commits: `git config --local commit.gpgsign true`.
+- Each commit lands as **Verified ✓** on GitHub when the GPG key is unlocked.
+- Web-app edits go through the Git Data API and pick up the OpenPGP private key the maintainer pasted into Settings → see the GPG note in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Branch + PR flow
+
+Per the maintainer's working style:
+
+1. Cut a feature branch from `main`.
+2. Implement + run `npm run typecheck && npm run build` (web) or `python scripts/<task>.py` (pipeline).
+3. Squash-commit with a short, scoped message.
+4. Push, open PR, squash-merge to `main` once green.
+
+Larger features (multi-task batches like the v3.x release cycle) are landed in phase-PRs that group related work to keep history scannable.
+
+## Related
+
+- [`pc_spec.md`](pc_spec.md) — hardware spec
+- [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md) — Tauri 2 desktop build prerequisites
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution paths (issue / web app / Telegram bot / extension / fork)
+- [`../web/README.md`](../web/README.md) — web stack details + per-phase changelog

--- a/docs/i18n/vi/dev_env.md
+++ b/docs/i18n/vi/dev_env.md
@@ -1,0 +1,87 @@
+# Môi trường dev
+
+IDE, toolchain ngôn ngữ, và workflow hàng ngày khi phát triển repo này. Bản tiếng Anh ở [`../../dev_env.md`](../../dev_env.md).
+
+## IDE
+
+| Tool       | Dùng cho                                                          |
+| ---------- | ----------------------------------------------------------------- |
+| PyCharm    | `scripts/` Python pipeline (fetcher, scraper, generator)          |
+| WebStorm   | `web/src/` React + TypeScript + Vite                              |
+| RustRover  | `web/src-tauri/` Tauri 2 desktop wrapper (Rust)                   |
+
+Lineup JetBrains, bản trả phí, channel **2026.x**. Editor khác (VS Code, Neovim, ...) cũng OK — repo không bind editor cụ thể.
+
+## Toolchain
+
+| Tool       | Version             | Ghi chú                                          |
+| ---------- | ------------------- | ------------------------------------------------ |
+| Python     | 3.12                | `scripts/` pipeline + Steam client               |
+| Node.js    | ≥ 22 (LTS)          | web build, pipeline build Tauri                  |
+| Rust       | stable (via rustup) | Tauri runtime                                    |
+| npm        | đi kèm Node         | `web/package-lock.json` là source of truth       |
+| Git        | mới                 | GPG signing on (`commit.gpgsign=true`)            |
+| Tauri CLI  | 2.x                 | gọi qua `npm run tauri ...`                       |
+
+CI workflow trong [`.github/workflows/`](../../../.github/workflows) đã pin các version này. Xem [`release-desktop.yml`](../../../.github/workflows/release-desktop.yml) cho matrix build desktop và [`deploy-pages.yml`](../../../.github/workflows/deploy-pages.yml) cho deploy web.
+
+## Workflow dev
+
+### Web app
+
+```bash
+cd web
+npm ci                   # cài lần đầu
+npm run dev              # http://localhost:5173 (Vite)
+npm run typecheck        # TS strict
+npm run build            # bundle production vào web/dist
+npm run preview          # serve bundle đã build
+```
+
+Cả `typecheck` lẫn `build` phải pass trước khi mở PR — phía React không có test suite chính thức, type-strict là safety net.
+
+### Tauri desktop
+
+```bash
+cd web
+npm run tauri dev        # dev build hot reload (Rust + WebKit)
+npm run tauri build      # release binary vào web/src-tauri/target/release/bundle
+```
+
+Platform prerequisites + ghi chú signing ở [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md).
+
+### Python pipeline
+
+```bash
+cd scripts
+python -m pip install -r requirements.txt   # nếu có file requirements
+python ingest_new.py                         # xử lý scripts/temp_info.jsonl
+python update_data.py                        # daily full refresh
+python top_online.py                         # rebuild games/top-online.md
+```
+
+Pipeline cố ý low-ceremony, không có unit test. Lint bằng `ruff` nếu có; còn lại dựa vào review.
+
+### Git + GPG
+
+- **Luôn** sign commit: `git config --local commit.gpgsign true`.
+- Mỗi commit hiện **Verified ✓** trên GitHub khi GPG key đã unlock.
+- Edit từ web-app đi qua Git Data API và lấy OpenPGP private key user paste vào Settings — xem note GPG trong [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md).
+
+## Branch + PR flow
+
+Theo style của maintainer:
+
+1. Cắt feature branch từ `main`.
+2. Implement + chạy `npm run typecheck && npm run build` (web) hoặc `python scripts/<task>.py` (pipeline).
+3. Squash-commit với message ngắn, scope rõ.
+4. Push, mở PR, squash-merge vào `main` khi green.
+
+Feature lớn (gộp nhiều task như v3.x) gom thành phase-PR để history dễ scan.
+
+## Liên quan
+
+- [`pc_spec.md`](pc_spec.md) — cấu hình máy
+- [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md) — yêu cầu build Tauri 2 desktop
+- [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md) — các đường đóng góp (issue / web app / Telegram bot / extension / fork)
+- [`../../../web/README.md`](../../../web/README.md) — chi tiết stack web + changelog từng phase

--- a/docs/i18n/vi/pc_spec.md
+++ b/docs/i18n/vi/pc_spec.md
@@ -1,0 +1,33 @@
+# Cấu hình máy dev
+
+File này ghi cấu hình máy mà maintainer (poli0981 / SkullMute) thực sự đang dùng để phát triển, build và test repo này. Bản tiếng Anh ở [`../../pc_spec.md`](../../pc_spec.md).
+
+Đây **không phải** yêu cầu hệ thống cho user — web app chạy trên mọi browser hiện đại, còn desktop app chỉ cần Tauri 2 platform deps (xem [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md)).
+
+## Máy dev chính
+
+| Component   | Chi tiết                                                         |
+| ----------- | ---------------------------------------------------------------- |
+| **OS**      | Windows 11 Pro 25H2 Insider Preview (Dev Channel)                |
+| **Build**   | 26300.8376                                                       |
+| **CPU**     | Intel Core i7-14700KF                                            |
+| **GPU**     | NVIDIA GeForce RTX 5080 (16 GB VRAM)                             |
+| **RAM**     | 32 GB DDR5                                                       |
+| **Storage** | 1 TB SSD                                                         |
+| **IDE**     | JetBrains 2026.x (bản trả phí) — PyCharm, WebStorm, RustRover    |
+
+## Thiết bị test (web app)
+
+Web app + desktop build được smoke-test trên:
+
+- **iPhone 14 Pro** — iOS 26.x, Safari + Chrome + Brave
+- **iPhone 13 Pro Max** — iOS 26.x, Safari + Chrome + Brave
+- **Desktop browser** — Chrome, Edge, Firefox, Brave (Windows 11)
+
+Ngoài danh sách trên là best-effort. Nếu render lỗi ở chỗ lạ, mở [bug report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml) — kèm browser + OS + screenshot.
+
+## Liên quan
+
+- [`dev_env.md`](dev_env.md) — IDE + toolchain + workflow dev
+- [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md) — yêu cầu build desktop
+- [`../../../AUTHORS.md`](../../../AUTHORS.md) — profile maintainer + liên hệ

--- a/docs/pc_spec.md
+++ b/docs/pc_spec.md
@@ -1,0 +1,33 @@
+# PC spec — developer machine
+
+This file documents the hardware the maintainer (poli0981 / SkullMute) actually uses to develop, build, and test this repo. It is mirrored in Vietnamese at [`i18n/vi/pc_spec.md`](i18n/vi/pc_spec.md).
+
+It is **not** a system requirement for users — the web app runs in any modern browser, and the desktop app only needs the Tauri 2 platform deps (see [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md)).
+
+## Developer machine (primary)
+
+| Component   | Details                                                     |
+| ----------- | ----------------------------------------------------------- |
+| **OS**      | Windows 11 Pro 25H2 Insider Preview (Dev Channel)           |
+| **Build**   | 26300.8376                                                  |
+| **CPU**     | Intel Core i7-14700KF                                       |
+| **GPU**     | NVIDIA GeForce RTX 5080 (16 GB VRAM)                        |
+| **RAM**     | 32 GB DDR5                                                  |
+| **Storage** | 1 TB SSD                                                    |
+| **IDE**     | JetBrains 2026.x — paid lineup (PyCharm, WebStorm, RustRover) |
+
+## Test devices (web app)
+
+The web app + desktop builds are smoke-tested on:
+
+- **iPhone 14 Pro** — iOS 26.x, Safari + Chrome + Brave
+- **iPhone 13 Pro Max** — iOS 26.x, Safari + Chrome + Brave
+- **Desktop browsers** — Chrome, Edge, Firefox, Brave (Windows 11)
+
+Anything outside this set is best-effort. File a [bug report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml) if rendering breaks somewhere unusual — include browser + OS + screenshot.
+
+## Related
+
+- [`dev_env.md`](dev_env.md) — IDE + toolchains + dev workflow
+- [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md) — desktop build prerequisites
+- [`../AUTHORS.md`](../AUTHORS.md) — maintainer profile + contact

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,0 +1,43 @@
+# Telegram bot — `@my_skull_bot`
+
+This is a pointer page. The **canonical user guide** lives in the bot's own repository:
+
+📖 **[poli0981/telegram-scraper-bot › docs/USER_GUIDE.md](https://github.com/poli0981/telegram-scraper-bot/blob/main/docs/USER_GUIDE.md)** — full command reference, edge cases, troubleshooting.
+
+🔗 **Bot source:** <https://github.com/poli0981/telegram-scraper-bot>
+
+🤖 **Bot handle:** [@my_skull_bot](https://t.me/my_skull_bot) ([QR](../assets/qr/telegram-bot.png))
+
+## What it does (in one paragraph)
+
+`@my_skull_bot` (a.k.a. *Scraper Info Game bot*) is a contributor convenience: instead of opening a GitHub issue or signing into the web app, you DM the bot a few Steam URLs and it dispatches the [`Bot Ingest` GitHub Actions workflow](../.github/workflows/bot-ingest.yml) on your behalf. The workflow appends your links to `scripts/temp_info.jsonl`, runs the same metadata fetch + dedup the daily pipeline uses, commits the result, and edits the bot's own Telegram message in real time with the outcome — `✅ Steam ingest done` or `❌ Steam ingest failed` with a workflow-run link.
+
+## How it works (lifecycle)
+
+1. **Whitelist (one-time)** — DM the maintainer privately on Telegram with your numeric `user_id`. The bot rejects messages from non-whitelisted IDs. **Never** post your `user_id` in public Discord, public Telegram groups, or GitHub issues.
+2. **Send Steam URLs** — full URL, short URL, or bare appid; one per line or one per message.
+3. **Bot validates + fetches metadata** — locally on the maintainer's machine.
+4. **Bot dispatches GitHub Actions** — passing your queue + your `chat_id` + the bot's own `message_id`.
+5. **GitHub Actions ingests** — same path as the daily pipeline. Commits + pushes if there are new records.
+6. **Bot edits its message** — success ✅ with summary, or failure ❌ with workflow-run link for debugging.
+
+For the full step-by-step (whitelist setup, command reference, what each prompt means, how to bulk-queue, troubleshooting), read the **[USER_GUIDE.md](https://github.com/poli0981/telegram-scraper-bot/blob/main/docs/USER_GUIDE.md)** in the bot repo.
+
+## Privacy first
+
+> [!WARNING]
+> Personal info — Telegram `user_id`, email, real name — should travel through DM only. **Do not** post your `user_id` in public Discord channels (including the project's own `#general`), public Telegram groups, GitHub issues, PR comments, commit messages, or public posts on X / Bluesky / Mastodon.
+>
+> The bot rejects messages from non-whitelisted IDs, so leaking the ID does not grant strangers access — but it still leaks your Telegram identity to anyone watching that channel. See [`../docs/PRIVACY_POLICY.md`](PRIVACY_POLICY.md) and [`../docs/ToS.md`](ToS.md) for the formal policy.
+
+## Availability
+
+The bot runs in **Docker on the maintainer's local machine**, ~2–5 hours per day depending on availability. There is no SLA. If it's offline, your messages sit unread until it's back up.
+
+## Related
+
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — section 3 has the in-repo flow + whitelist instructions
+- [`../.github/workflows/bot-ingest.yml`](../.github/workflows/bot-ingest.yml) — the Actions workflow the bot dispatches
+- [`../AUTHORS.md`](../AUTHORS.md) — maintainer DM channels for whitelist requests
+- [`../assets/qr/telegram-bot.png`](../assets/qr/telegram-bot.png) — bot QR code
+- [`../assets/qr/telegram-user.png`](../assets/qr/telegram-user.png) — maintainer DM QR code

--- a/scripts/core/constants.py
+++ b/scripts/core/constants.py
@@ -79,3 +79,4 @@ EXTENSION_FIELDS = frozenset({
 # ──────────── Table generation ────────────
 MAX_GAMES_PER_FILE = 200
 TOP_ONLINE_LIMIT   = 50
+TOP_OFFLINE_LIMIT  = 100

--- a/scripts/core/fetcher.py
+++ b/scripts/core/fetcher.py
@@ -247,16 +247,35 @@ def update_reviews_only(games):
     process_batch(games, fn, "Reviews")
 
 
-def update_players_only(games):
+def update_players_only(games, type_filter: str = "online"):
+    """Refresh `current_players` + `peak_today` for the games matching
+    `type_filter`. Default 'online' preserves the historical behaviour
+    used by top_online.py.
+
+    type_filter:
+      - "online"  → only games with type_game == 'online' (default).
+      - "offline" → games with a non-empty type_game that is NOT 'online'
+                    (single-player, story, etc). Empty type_game is
+                    excluded — those are unclassified, not offline.
+      - "all"     → every game with a non-empty type_game.
+    """
     if not STEAM_API_KEY:
         print("No STEAM_API_KEY.")
         return
-    online = [g for g in games if g.get("type_game", "").lower() == "online"]
-    print(f"Players update: {len(online)} online games")
+    if type_filter == "offline":
+        target = [
+            g for g in games
+            if (g.get("type_game", "").lower() or "") not in ("online", "")
+        ]
+    elif type_filter == "all":
+        target = [g for g in games if g.get("type_game", "")]
+    else:  # "online" (default + safety fallback)
+        target = [g for g in games if g.get("type_game", "").lower() == "online"]
+    print(f"Players update ({type_filter}): {len(target)} games")
     client = get_client()
     def fn(g):
         appid = extract_appid(g.get("link", ""))
         if not appid: return
         count = client.fetch_player_count(appid, STEAM_API_KEY)
         if count is not None: apply_players(g, count)
-    process_batch(online, fn, "Players")
+    process_batch(target, fn, "Players")

--- a/scripts/top_offline.py
+++ b/scripts/top_offline.py
@@ -68,7 +68,7 @@ def main():
     for g in offline:
         aid = extract_appid(g.get("link", ""))
         if aid: prev[aid] = _ppc(g.get("current_players", "0"))
-    update_players_only(games)
+    update_players_only(games, type_filter="offline")
     # Re-filter after update (status may have changed).
     offline = [g for g in games if _is_offline(g) and g.get("status", "active") == "active"]
     offline.sort(key=lambda g: _ppc(g.get("current_players", "0")), reverse=True)

--- a/scripts/top_offline.py
+++ b/scripts/top_offline.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Top offline (single-player / non-online) leaderboard.
+
+Mirrors top_online.py but filters games whose `type_game` is NOT "online".
+Steam reports concurrent player counts for offline titles too — single-player
+hits, demos, story games can still rack up concurrents during sales or
+patch days, so this leaderboard surfaces what's actually being played
+beyond the always-online crowd.
+
+Output: games/top-offline.md (10 columns, same shape as top-online.md).
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from datetime import datetime, timezone
+from core.constants import STEAM_API_KEY, GAMES_DIR, TOP_OFFLINE_LIMIT
+from core.data_store import load_main, save_main, extract_appid
+from core.fetcher import update_players_only
+
+def _ppc(s):
+    c = s.replace(",", "").strip()
+    return int(c) if c.isdigit() else 0
+
+# Tiers calibrated lower than top-online — offline games rarely hit
+# 6-figure concurrents, so the same scale would flatten everything to 💀.
+_TIERS = [(20000, "🔥 Mega"), (5000, "⭐ Hot"), (1500, "🟢 Healthy"),
+          (300, "🟡 Stable"), (50, "🟠 Low"), (10, "🔴 Quiet")]
+
+def _tier(c):
+    for thresh, label in _TIERS:
+        if c >= thresh: return label
+    return "💀 Idle"
+
+def _trend(cur, prev):
+    if prev == 0: return "🆕"
+    d = ((cur - prev) / prev) * 100
+    if d > 15: return f"📈+{d:.0f}%"
+    if d > 3:  return f"↑+{d:.0f}%"
+    if d < -15: return f"📉{d:.0f}%"
+    if d < -3:  return f"↓{d:.0f}%"
+    return "→"
+
+_STAR_THRESHOLDS = [(95, "★★★★★"), (80, "★★★★☆"), (70, "★★★☆☆"), (50, "★★☆☆☆")]
+
+def _stars(r):
+    try: p = int(r.split("%")[0])
+    except: return "—"
+    for thresh, s in _STAR_THRESHOLDS:
+        if p >= thresh: return s
+    return "★☆☆☆☆"
+
+def _is_offline(g):
+    t = g.get("type_game", "").lower()
+    # Treat anything that isn't explicitly online as offline. Empty
+    # type_game is excluded — those are unclassified, not offline.
+    return t and t != "online"
+
+def main():
+    if not STEAM_API_KEY:
+        print("No Steam API key (set STEAM_API_KEY).")
+        sys.exit(1)
+    games = load_main()
+    offline = [g for g in games if _is_offline(g) and g.get("status", "active") == "active"]
+    if not offline:
+        print("No offline games found.")
+        sys.exit(1)
+    print(f"{len(offline)} offline games to refresh...")
+    prev = {}
+    for g in offline:
+        aid = extract_appid(g.get("link", ""))
+        if aid: prev[aid] = _ppc(g.get("current_players", "0"))
+    update_players_only(games)
+    # Re-filter after update (status may have changed).
+    offline = [g for g in games if _is_offline(g) and g.get("status", "active") == "active"]
+    offline.sort(key=lambda g: _ppc(g.get("current_players", "0")), reverse=True)
+    tp = sum(_ppc(g.get("current_players", "0")) for g in offline)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    os.makedirs(GAMES_DIR, exist_ok=True)
+    with open(f"{GAMES_DIR}/top-offline.md", "w") as f:
+        f.write(f"# 🎮 Top Offline – Single-Player Leaderboard\n\n")
+        f.write(f"> {now} | {len(offline)} offline games | {tp:,} concurrent players\n\n")
+        f.write("Free-to-play Steam games where `type_game` is set to anything other "
+                "than `online` (typically single-player, demos, or story-driven titles). "
+                "Refreshed bi-weekly via `top-offline.yml`.\n\n")
+        f.write("| # | Game | Players | Trend | Tier | Rating | Genre | AC | Peak | Link |\n")
+        f.write("|---|------|---------|-------|------|--------|-------|----|------|------|\n")
+        for rank, g in enumerate(offline[:TOP_OFFLINE_LIMIT], 1):
+            aid = extract_appid(g.get("link", ""))
+            c = _ppc(g.get("current_players", "0"))
+            n = g.get("name", "?")
+            if len(n) > 40: n = n[:37] + "..."
+            ac = g.get("anti_cheat", "-")
+            if g.get("is_kernel_ac") is True and ac != "-": ac += "🔴"
+            f.write(f"| {rank} | {n} | {g.get('current_players', 'N/A')} "
+                    f"| {_trend(c, prev.get(aid, 0))} | {_tier(c)} | {_stars(g.get('reviews', 'N/A'))} "
+                    f"| {g.get('genre', 'N/A')} | {ac} | {g.get('peak_today', 'N/A')} "
+                    f"| [Steam]({g.get('link', '#')}) |\n")
+        rest = offline[TOP_OFFLINE_LIMIT:]
+        if rest:
+            quiet = sum(1 for g in rest if _ppc(g.get("current_players", "0")) < 10)
+            f.write(f"\n*+{len(rest)} more ({quiet} <10 players)*\n")
+    save_main(games)
+    print(f"✓ → {GAMES_DIR}/top-offline.md")
+
+if __name__ == "__main__": main()

--- a/web/index.html
+++ b/web/index.html
@@ -2,11 +2,83 @@
 <html lang="vi" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='18' fill='%231e293b'/%3E%3Ctext x='50' y='66' font-family='system-ui' font-size='62' font-weight='700' text-anchor='middle' fill='%2360a5fa'%3E▶%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0f172a" />
-    <meta name="description" content="Steam Free-to-Play games tracker — browse, analyze, and manage 1,200+ F2P games" />
+
     <title>Steam F2P Tracker</title>
+    <meta
+      name="description"
+      content="Curated list of 1,200+ free-to-play Steam games — browse, search, filter by genre/anti-cheat/players, view live leaderboards, export to CSV/JSON. Open-source, MIT-licensed."
+    />
+    <meta name="author" content="poli0981 / SkullMute" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://poli0981.github.io/free-steam-games-list/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Steam F2P Tracker" />
+    <meta property="og:title" content="Steam F2P Tracker — 1,200+ free-to-play games" />
+    <meta
+      property="og:description"
+      content="Browse, analyse, and edit a curated list of 1,200+ free-to-play Steam games. Live player leaderboards, 12 charts, fuzzy search, multi-language UI."
+    />
+    <meta property="og:url" content="https://poli0981.github.io/free-steam-games-list/" />
+    <meta property="og:image" content="https://poli0981.github.io/free-steam-games-list/icon-512.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
+    <meta property="og:locale" content="vi_VN" />
+    <meta property="og:locale:alternate" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Steam F2P Tracker — 1,200+ free-to-play games" />
+    <meta
+      name="twitter:description"
+      content="Curated, auto-refreshed list of free-to-play Steam games. Browse / charts / leaderboards. Open-source."
+    />
+    <meta name="twitter:image" content="https://poli0981.github.io/free-steam-games-list/icon-512.svg" />
+    <meta name="twitter:creator" content="@SkullMute0011" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "https://poli0981.github.io/free-steam-games-list/#website",
+            "url": "https://poli0981.github.io/free-steam-games-list/",
+            "name": "Steam F2P Tracker",
+            "description": "Curated list of 1,200+ free-to-play Steam games.",
+            "inLanguage": ["vi", "en"],
+            "publisher": { "@id": "https://github.com/poli0981#person" }
+          },
+          {
+            "@type": "Person",
+            "@id": "https://github.com/poli0981#person",
+            "name": "poli0981",
+            "alternateName": "SkullMute",
+            "url": "https://github.com/poli0981",
+            "sameAs": [
+              "https://x.com/SkullMute0011",
+              "https://www.youtube.com/@SkullMute",
+              "https://bsky.app/profile/skullmute0011.bsky.social",
+              "https://mastodon.social/@skullmute1122"
+            ]
+          },
+          {
+            "@type": "SoftwareApplication",
+            "name": "Steam F2P Tracker",
+            "applicationCategory": "BrowserApplication",
+            "operatingSystem": "Web, Windows, macOS, Linux",
+            "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+            "license": "https://opensource.org/licenses/MIT"
+          }
+        ]
+      }
+    </script>
   </head>
   <body class="bg-background text-foreground antialiased">
     <div id="root"></div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -5035,7 +5035,7 @@
       }
     },
     "node_modules/detect-node-es": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
@@ -5671,7 +5671,7 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
@@ -5763,7 +5763,7 @@
       "license": "ISC"
     },
     "node_modules/has-bigints": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
@@ -5805,7 +5805,7 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
@@ -5900,7 +5900,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/internal-slot": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
@@ -5953,7 +5953,7 @@
       }
     },
     "node_modules/is-bigint": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
@@ -6044,7 +6044,7 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
@@ -6557,7 +6557,7 @@
       }
     },
     "node_modules/math-intrinsics": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
@@ -6842,7 +6842,7 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
@@ -7367,7 +7367,7 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
@@ -7482,7 +7482,7 @@
       }
     },
     "node_modules/safe-regex-test": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
@@ -7601,7 +7601,7 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
@@ -7760,7 +7760,7 @@
       }
     },
     "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
@@ -8236,7 +8236,7 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://poli0981.github.io/free-steam-games-list/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://poli0981.github.io/free-steam-games-list/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://github.com/poli0981/free-steam-games-list</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://github.com/poli0981/free-steam-games-list/blob/main/games/all-games_part1.md</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://github.com/poli0981/free-steam-games-list/blob/main/games/top-online.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://github.com/poli0981/free-steam-games-list/blob/main/CHANGELOG.md</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.1.0"
+version = "1.2.0"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/TAURI.md
+++ b/web/src-tauri/TAURI.md
@@ -1,0 +1,92 @@
+# Tauri 2 desktop build
+
+This file documents how to build and run the desktop wrapper around the React web app. CI builds use the same recipe via [`.github/workflows/release-desktop.yml`](../../.github/workflows/release-desktop.yml).
+
+## Prerequisites
+
+| Tool       | Version             | Install                                                     |
+| ---------- | ------------------- | ----------------------------------------------------------- |
+| Node.js    | ≥ 22 (LTS)          | <https://nodejs.org/>                                       |
+| Rust       | stable (via rustup) | <https://rustup.rs/>                                        |
+| npm        | bundled with Node   | comes with Node                                             |
+| Tauri CLI  | 2.x                 | invoked via `npx tauri` or `npm run tauri ...`               |
+
+### Platform-specific deps
+
+**Windows** — nothing extra (Tauri 2 ships its own WebView2 detection; install [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/) if missing).
+
+**macOS** — Xcode Command Line Tools:
+```bash
+xcode-select --install
+```
+
+**Linux (Ubuntu/Debian)** — same packages CI installs:
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev \
+  libappindicator3-dev \
+  librsvg2-dev \
+  patchelf \
+  libssl-dev \
+  build-essential \
+  curl wget file
+```
+
+## Local dev
+
+```bash
+cd web
+npm ci                  # install web deps once
+npm run tauri dev       # dev build with hot reload
+```
+
+This boots Vite (`npm run dev`) under the hood and wires Tauri to it. The window opens at fixed 1400×900, dark theme, no resize.
+
+## Production build
+
+```bash
+cd web
+npm run tauri build
+```
+
+Output bundles land in `web/src-tauri/target/release/bundle/`:
+
+| Platform | Artefact                  |
+| -------- | ------------------------- |
+| Windows  | `.msi`                    |
+| macOS    | `.dmg` (universal binary) |
+| Linux    | `.AppImage`, `.deb`       |
+
+## Auto-update + signing
+
+From v1.0 onwards the app polls the GitHub Releases page on launch and offers to download the next signed build. Updater clients reject unsigned binaries.
+
+- Public minisign key is baked into [`tauri.conf.json`](tauri.conf.json).
+- Private key + (optional) password live in repo Secrets:
+  - `TAURI_SIGNING_PRIVATE_KEY`
+  - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+- The CI workflow injects them at build time. Local builds without these secrets still produce binaries, but updater clients won't trust them.
+
+## CI
+
+`.github/workflows/release-desktop.yml` triggers on:
+
+- Push of any `desktop-v*` tag (e.g. `desktop-v1.1.0`)
+- Manual `workflow_dispatch` with a tag input
+
+It runs the build matrix (Win / macOS-universal / Linux), uploads installers as draft Release assets, and emits `latest.json` for the auto-updater (`includeUpdaterJson: true`).
+
+## Troubleshooting
+
+- **WebKit missing on Linux** — install `libwebkit2gtk-4.1-dev`. The CI workflow's apt-install line is the canonical list.
+- **`napi-rs` build fails** — verify Rust toolchain is `stable` and `rustup target list --installed` includes the host triple.
+- **macOS universal binary** — ensure both `aarch64-apple-darwin` and `x86_64-apple-darwin` targets are added (`rustup target add ...`). CI does this in the `dtolnay/rust-toolchain` step.
+- **Updater silent on sideloaded copies** — sideloaded installs have a different bundle identifier; only the official MSI/DMG/AppImage receive update prompts.
+
+## Related
+
+- [`../../docs/dev_env.md`](../../docs/dev_env.md) — IDE + toolchain
+- [`../../docs/pc_spec.md`](../../docs/pc_spec.md) — maintainer hardware spec
+- [`../../.github/workflows/release-desktop.yml`](../../.github/workflows/release-desktop.yml) — CI build pipeline
+- [Tauri 2 docs](https://v2.tauri.app/) — upstream

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { HealthPage } from "./pages/Health";
 import { ActivityPage } from "./pages/Activity";
 import { AddPage } from "./pages/Add";
 import { AboutPage } from "./pages/About";
+import { DonatePage } from "./pages/Donate";
 import { SettingsPage } from "./pages/Settings";
 
 export default function App() {
@@ -42,6 +43,7 @@ export default function App() {
         <Route path="activity" element={<ActivityPage />} />
         <Route path="add" element={<AddPage />} />
         <Route path="about" element={<AboutPage />} />
+        <Route path="donate" element={<DonatePage />} />
         <Route path="settings" element={<SettingsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>

--- a/web/src/components/games/GameDetailDrawer.tsx
+++ b/web/src/components/games/GameDetailDrawer.tsx
@@ -19,6 +19,7 @@ import {
   Globe,
   Tag,
   Pencil,
+  Monitor,
 } from "lucide-react";
 import {
   formatNumber,
@@ -27,6 +28,7 @@ import {
   formatRelativeDate,
 } from "../../lib/utils";
 import { extractAppid } from "../../lib/data-store";
+import { steamProtocolUrl, steamWebUrl } from "../../lib/steam-link";
 import { webpProxyUrl } from "../../lib/image";
 import type { GameRecord } from "../../lib/schema";
 import { EditGameDrawer } from "./EditGameDrawer";
@@ -120,16 +122,38 @@ export function GameDetailDrawer({ game, onClose, missing }: Props) {
                   </Button>
                 )}
               </div>
-              <DialogDescription>
-                <a
-                  href={game.link}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-primary hover:underline"
-                >
-                  {t("detail.openOnSteam", { appid: extractAppid(game.link) })}{" "}
-                  <ExternalLink className="h-3 w-3" />
-                </a>
+              <DialogDescription asChild>
+                <div className="space-y-1.5">
+                  <div className="text-xs text-muted-foreground">
+                    {t("detail.openOnSteam", { appid: extractAppid(game.link) })}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {(() => {
+                      const appid = extractAppid(game.link);
+                      const protocol = appid ? steamProtocolUrl(appid) : game.link;
+                      const web = appid ? steamWebUrl(appid) : game.link;
+                      return (
+                        <>
+                          <Button asChild size="sm" variant="default">
+                            <a
+                              href={protocol}
+                              title={t("detail.openOnSteamDesktopHint")}
+                            >
+                              <Monitor className="mr-1 h-3 w-3" />
+                              {t("detail.openOnSteamDesktop")}
+                            </a>
+                          </Button>
+                          <Button asChild size="sm" variant="outline">
+                            <a href={web} target="_blank" rel="noopener noreferrer">
+                              <ExternalLink className="mr-1 h-3 w-3" />
+                              {t("detail.openOnSteamWeb")}
+                            </a>
+                          </Button>
+                        </>
+                      );
+                    })()}
+                  </div>
+                </div>
               </DialogDescription>
             </DialogHeader>
 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Lock,
   History,
   Info,
+  Heart,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { Sheet, SheetContent } from "../ui/sheet";
@@ -59,6 +60,7 @@ const SECONDARY: NavItemWithOwner[] = [
   { to: "/activity", i18n: "nav.activity", icon: History },
   { to: "/add", i18n: "nav.add", icon: PlusCircle, ownerOnly: true },
   { to: "/about", i18n: "nav.about", icon: Info },
+  { to: "/donate", i18n: "nav.donate", icon: Heart },
   { to: "/settings", i18n: "nav.settings", icon: Settings },
 ];
 

--- a/web/src/hooks/useDocumentTitle.ts
+++ b/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+const SITE_NAME = "Steam F2P Tracker";
+
+/**
+ * Sets `document.title` to `<page> · <SITE_NAME>` on mount, restores on unmount.
+ *
+ * Pass either an i18n key (resolves via `t()`) or a literal string. The hook
+ * re-runs when the resolved title changes — switching language updates the
+ * tab title automatically.
+ */
+export function useDocumentTitle(titleOrKey: string, opts?: { isKey?: boolean }) {
+  const { t, i18n } = useTranslation();
+  const isKey = opts?.isKey ?? true;
+  const resolved = isKey ? t(titleOrKey) : titleOrKey;
+
+  useEffect(() => {
+    const previous = document.title;
+    document.title = resolved ? `${resolved} · ${SITE_NAME}` : SITE_NAME;
+    return () => {
+      document.title = previous;
+    };
+    // i18n.language is in the deps because t() output changes with language.
+  }, [resolved, i18n.language]);
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -18,6 +18,7 @@
     "activity": "Activity",
     "add": "Add",
     "about": "About",
+    "donate": "Donate",
     "settings": "Settings"
   },
   "common": {
@@ -299,6 +300,24 @@
     "lockGpgKey": "Lock GPG key",
     "unlockGpgSettings": "Unlock GPG key (Settings)"
   },
+  "donate": {
+    "title": "Support the project",
+    "subtitle": "If this list saved you a Steam-search rabbit hole, consider buying the maintainer a coffee or a sale-priced indie game. 100% goes to instant noodles + the next $5 sale binge.",
+    "cta": "Open",
+    "footnote": "Same handles as in .github/FUNDING.yml. The GitHub repo's Sponsor button at the top of every page also funnels here.",
+    "platform": {
+      "github": "GitHub Sponsors",
+      "githubDesc": "Recurring or one-off, fee-free, plugs straight into the maintainer's GitHub profile.",
+      "kofi": "Ko-fi",
+      "kofiDesc": "One-off coffees or monthly memberships. No fees on one-time tips.",
+      "bmc": "Buy Me a Coffee",
+      "bmcDesc": "Same idea as Ko-fi — different platform if you already have an account here.",
+      "patreon": "Patreon",
+      "patreonDesc": "Monthly tiers — best if you'd like the maintainer to keep this running long-term.",
+      "paypal": "PayPal",
+      "paypalDesc": "Direct PayPal.me link. Use this if every other platform is blocked in your region."
+    }
+  },
   "about": {
     "title": "About",
     "subtitle": "The repo, the dev, the stack, the legal stuff, and the fine print on accuracy.",
@@ -333,6 +352,8 @@
     "groupMissingDesc": "Missing one or more of: genre / type_game / safe.",
     "groupKernel": "Online + AC + kernel unknown",
     "groupKernelDesc": "type_game=online with an anti-cheat name set but is_kernel_ac is null.",
+    "groupOnlineAcUnknown": "Online · anti-cheat unknown / none",
+    "groupOnlineAcUnknownDesc": "type_game=online with anti_cheat empty or '-'. May be unknown, may genuinely have none.",
     "moreItems": "+{{count}} more…",
     "maintenanceTriggers": "Maintenance triggers",
     "maintenanceDesc": "Manually fire the existing GitHub Actions workflows. Requires sign-in with {{scope}} scope.",
@@ -342,6 +363,8 @@
     "triggerUpdateReviewsDesc": "Reviews-only refresh",
     "triggerTopOnline": "Top online",
     "triggerTopOnlineDesc": "Player leaderboard",
+    "triggerTopOffline": "Top offline",
+    "triggerTopOfflineDesc": "Single-player concurrents (bi-weekly)",
     "triggerCheckLinks": "Check dead links",
     "triggerCheckLinksDesc": "HEAD scan all app pages",
     "triggerPurge": "Purge unhealthy",
@@ -373,6 +396,9 @@
   },
   "detail": {
     "openOnSteam": "appid {{appid}} · open on Steam",
+    "openOnSteamDesktop": "Steam Desktop",
+    "openOnSteamDesktopHint": "Opens in the Steam client if installed (steam://). Otherwise the browser will show a protocol prompt — fall back to the Web button.",
+    "openOnSteamWeb": "Web",
     "labelGenre": "Genre",
     "labelType": "Type",
     "labelDeveloper": "Developer",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -18,6 +18,7 @@
     "activity": "Hoạt động",
     "add": "Thêm",
     "about": "Giới thiệu",
+    "donate": "Ủng hộ",
     "settings": "Cài đặt"
   },
   "common": {
@@ -299,6 +300,24 @@
     "lockGpgKey": "Khoá GPG key",
     "unlockGpgSettings": "Unlock GPG key (mở Settings)"
   },
+  "donate": {
+    "title": "Ủng hộ dự án",
+    "subtitle": "Nếu cái list này tiết kiệm cho bạn cả buổi search trên Steam, mời maintainer 1 ly cà phê hoặc 1 game indie sale giá rẻ. 100% đi vào mì tôm + lần sale $5 tiếp theo.",
+    "cta": "Mở",
+    "footnote": "Cùng handle với .github/FUNDING.yml. Nút Sponsor trên đầu mọi page của repo GitHub cũng dẫn về đây.",
+    "platform": {
+      "github": "GitHub Sponsors",
+      "githubDesc": "Định kỳ hoặc 1 lần, miễn phí, gắn thẳng vào profile GitHub của maintainer.",
+      "kofi": "Ko-fi",
+      "kofiDesc": "Cà phê 1 lần hoặc membership tháng. Không thu phí với tip 1 lần.",
+      "bmc": "Buy Me a Coffee",
+      "bmcDesc": "Ý tưởng giống Ko-fi — chọn nếu bạn đã có account ở đây.",
+      "patreon": "Patreon",
+      "patreonDesc": "Subscribe theo tháng — tốt nếu bạn muốn maintainer duy trì project lâu dài.",
+      "paypal": "PayPal",
+      "paypalDesc": "Link PayPal.me trực tiếp. Dùng khi các platform khác bị chặn ở vùng bạn."
+    }
+  },
   "about": {
     "title": "Giới thiệu",
     "subtitle": "Repo, dev, stack, phần legal, và những lưu ý về độ chính xác.",
@@ -333,6 +352,8 @@
     "groupMissingDesc": "Thiếu 1 hoặc nhiều trong: genre / type_game / safe.",
     "groupKernel": "Online + AC + chưa rõ kernel",
     "groupKernelDesc": "type_game=online có anti-cheat name nhưng is_kernel_ac là null.",
+    "groupOnlineAcUnknown": "Online · chưa biết / không có anti-cheat",
+    "groupOnlineAcUnknownDesc": "type_game=online với anti_cheat rỗng hoặc '-'. Có thể chưa biết, có thể thật sự không có.",
     "moreItems": "+{{count}} mục nữa…",
     "maintenanceTriggers": "Nút maintenance",
     "maintenanceDesc": "Trigger thủ công các workflow GitHub Actions hiện có. Cần đăng nhập với scope {{scope}}.",
@@ -342,6 +363,8 @@
     "triggerUpdateReviewsDesc": "Refresh chỉ reviews",
     "triggerTopOnline": "Top online",
     "triggerTopOnlineDesc": "Bảng xếp hạng người chơi",
+    "triggerTopOffline": "Top offline",
+    "triggerTopOfflineDesc": "Người chơi single-player (2 tuần/lần)",
     "triggerCheckLinks": "Check link chết",
     "triggerCheckLinksDesc": "Scan HEAD mọi trang app",
     "triggerPurge": "Purge unhealthy",
@@ -373,6 +396,9 @@
   },
   "detail": {
     "openOnSteam": "appid {{appid}} · mở trên Steam",
+    "openOnSteamDesktop": "Steam Desktop",
+    "openOnSteamDesktopHint": "Mở trong Steam client nếu đã cài (steam://). Nếu chưa cài, browser sẽ hiện protocol prompt — dùng nút Web thay thế.",
+    "openOnSteamWeb": "Web",
     "labelGenre": "Thể loại",
     "labelType": "Loại",
     "labelDeveloper": "Developer",

--- a/web/src/lib/steam-link.ts
+++ b/web/src/lib/steam-link.ts
@@ -1,0 +1,20 @@
+/**
+ * Steam URL helpers — produce both the `steam://` deep link (opens the
+ * Steam desktop client if installed) and the regular https store URL.
+ *
+ * The web build always renders BOTH buttons because there is no reliable
+ * way to detect whether the Steam protocol handler is registered. Users
+ * with the desktop client installed get the native flow; users without it
+ * fall back to the browser. The Tauri desktop wrapper allows steam://
+ * navigation by default.
+ */
+
+/** `steam://store/<appid>` — opens the store page in the desktop client. */
+export function steamProtocolUrl(appid: string): string {
+  return `steam://store/${appid}`;
+}
+
+/** Standard https store page. */
+export function steamWebUrl(appid: string): string {
+  return `https://store.steampowered.com/app/${appid}/`;
+}

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -25,6 +25,7 @@ import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { Separator } from "../components/ui/separator";
 import { useGames } from "../hooks/useGames";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { REPO_OWNER, REPO_NAME } from "../lib/schema";
 import { formatNumber } from "../lib/utils";
 
@@ -120,6 +121,7 @@ const LEGAL_DOCS: LegalDoc[] = [
 
 export function AboutPage() {
   const { t } = useTranslation();
+  useDocumentTitle("about.title");
   const games = useGames();
   const total = games.data?.records.length ?? 0;
   const lastUpdated = games.data?.index.last_updated ?? "";
@@ -312,6 +314,47 @@ export function AboutPage() {
               another channel — <strong>do not</strong> post it in public Discord channels,
               public Telegram groups, or repo issues. See <a href={`${REPO_URL}/blob/main/CONTRIBUTING.md`} className="text-primary hover:underline" target="_blank" rel="noreferrer">CONTRIBUTING.md</a> for the full flow.
             </p>
+          </div>
+          <div className="rounded-md border bg-card p-3 text-xs text-muted-foreground">
+            <div className="mb-1 flex items-center gap-1.5 font-semibold text-foreground">
+              <Bot className="h-3.5 w-3.5" /> Bot user guide & source
+            </div>
+            <ul className="list-disc space-y-0.5 pl-5">
+              <li>
+                Full user guide:{" "}
+                <a
+                  href="https://github.com/poli0981/telegram-scraper-bot/blob/main/docs/USER_GUIDE.md"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  USER_GUIDE.md
+                </a>{" "}
+                — command reference, edge cases, troubleshooting.
+              </li>
+              <li>
+                Bot source:{" "}
+                <a
+                  href="https://github.com/poli0981/telegram-scraper-bot"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  poli0981/telegram-scraper-bot
+                </a>
+              </li>
+              <li>
+                In-repo summary:{" "}
+                <a
+                  href={`${REPO_URL}/blob/main/docs/telegram-bot.md`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  docs/telegram-bot.md
+                </a>
+              </li>
+            </ul>
           </div>
         </CardContent>
       </Card>

--- a/web/src/pages/Activity.tsx
+++ b/web/src/pages/Activity.tsx
@@ -15,6 +15,7 @@ import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { LoadingState, ErrorState } from "../components/common/QueryState";
 import { useAuth } from "../stores/auth";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { REPO_OWNER, REPO_NAME, DEFAULT_BRANCH } from "../lib/schema";
 import { formatRelativeDate } from "../lib/utils";
 import { cn } from "../lib/utils";
@@ -49,6 +50,7 @@ async function fetchCommits(token: string | null): Promise<Commit[]> {
 
 export function ActivityPage() {
   const { t } = useTranslation();
+  useDocumentTitle("activity.title");
   const auth = useAuth();
   const [filter, setFilter] = useState<Filter>("all");
 

--- a/web/src/pages/Add.tsx
+++ b/web/src/pages/Add.tsx
@@ -30,6 +30,7 @@ import { Label } from "../components/ui/label";
 import { Separator } from "../components/ui/separator";
 import { useAuth } from "../stores/auth";
 import { useGames } from "../hooks/useGames";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useCommitContext, type CommitContext } from "../hooks/useCommitContext";
 import { useIsOwner } from "../hooks/useIsOwner";
 import { addLinks, type AddEntry } from "../lib/edits";
@@ -45,6 +46,7 @@ import {
 
 export function AddPage() {
   const { t } = useTranslation();
+  useDocumentTitle("add.title");
   const auth = useAuth();
   const ctx = useCommitContext();
   const isOwner = useIsOwner();

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../hooks/useGames";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { KpiCards } from "../components/charts/KpiCards";
 import { GenreTreemap } from "../components/charts/GenreTreemap";
 import { PlatformsDonut } from "../components/charts/PlatformsDonut";
@@ -9,6 +10,7 @@ import { LoadingState, ErrorState } from "../components/common/QueryState";
 
 export function Dashboard() {
   const { t } = useTranslation();
+  useDocumentTitle("dashboard.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/Donate.tsx
+++ b/web/src/pages/Donate.tsx
@@ -1,0 +1,91 @@
+import { Heart, Coffee, Gift, Github, CreditCard, ExternalLink } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
+
+interface DonationPlatform {
+  /** i18n key suffix under `donate.platform.*` for label/desc. */
+  key: "github" | "kofi" | "bmc" | "patreon" | "paypal";
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  /** Tailwind classes for accent ring + icon tint. */
+  accent: string;
+}
+
+const PLATFORMS: DonationPlatform[] = [
+  {
+    key: "github",
+    href: "https://github.com/sponsors/poli0981",
+    icon: Github,
+    accent: "ring-violet-500/30 text-violet-400",
+  },
+  {
+    key: "kofi",
+    href: "https://ko-fi.com/skullmute",
+    icon: Coffee,
+    accent: "ring-rose-500/30 text-rose-400",
+  },
+  {
+    key: "bmc",
+    href: "https://buymeacoffee.com/skullmute",
+    icon: Coffee,
+    accent: "ring-amber-500/30 text-amber-400",
+  },
+  {
+    key: "patreon",
+    href: "https://patreon.com/skullmute",
+    icon: Gift,
+    accent: "ring-orange-500/30 text-orange-400",
+  },
+  {
+    key: "paypal",
+    href: "https://paypal.me/DungDang212",
+    icon: CreditCard,
+    accent: "ring-blue-500/30 text-blue-400",
+  },
+];
+
+export function DonatePage() {
+  const { t } = useTranslation();
+  useDocumentTitle("donate.title");
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+          <Heart className="h-6 w-6 text-rose-400" /> {t("donate.title")}
+        </h1>
+        <p className="text-sm text-muted-foreground">{t("donate.subtitle")}</p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {PLATFORMS.map((p) => (
+          <Card key={p.key} className="flex flex-col">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <span
+                  className={`grid h-9 w-9 place-items-center rounded-md bg-card ring-1 ${p.accent}`}
+                >
+                  <p.icon className="h-4 w-4" />
+                </span>
+                {t(`donate.platform.${p.key}`)}
+              </CardTitle>
+              <CardDescription className="text-xs">
+                {t(`donate.platform.${p.key}Desc`)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="mt-auto">
+              <Button asChild variant="outline" size="sm" className="w-full">
+                <a href={p.href} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="mr-1 h-3 w-3" /> {t("donate.cta")}
+                </a>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{t("donate.footnote")}</p>
+    </div>
+  );
+}

--- a/web/src/pages/Games.tsx
+++ b/web/src/pages/Games.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { useGames } from "../hooks/useGames";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { GamesTable } from "../components/games/GamesTable";
 import { GameDetailDrawer } from "../components/games/GameDetailDrawer";
 import { LoadingState, ErrorState } from "../components/common/QueryState";
@@ -12,6 +13,7 @@ import { X } from "lucide-react";
 
 export function GamesPage() {
   const { t } = useTranslation();
+  useDocumentTitle("games.title");
   const q = useGames();
   const navigate = useNavigate();
   const { appid } = useParams<{ appid: string }>();

--- a/web/src/pages/Health.tsx
+++ b/web/src/pages/Health.tsx
@@ -11,11 +11,13 @@ import {
   Link as LinkIcon,
   Calendar,
   Sparkles,
+  ShieldQuestion,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { useGames } from "../hooks/useGames";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAuth } from "../stores/auth";
 import { LoadingState, ErrorState } from "../components/common/QueryState";
 import { dispatchWorkflow } from "../lib/github-api";
@@ -25,7 +27,7 @@ import { formatNumber, formatRelativeDate } from "../lib/utils";
 
 interface IssueGroup {
   /** i18n key suffix under `health.group{Suffix}` for label, `Desc` for description. */
-  key: "Delisted" | "Stale" | "Missing" | "Kernel";
+  key: "Delisted" | "Stale" | "Missing" | "Kernel" | "OnlineAcUnknown";
   records: GameRecord[];
   icon: React.ComponentType<{ className?: string }>;
   variant: "warning" | "destructive" | "secondary";
@@ -36,6 +38,7 @@ function gatherIssues(records: GameRecord[]): IssueGroup[] {
   const stale: GameRecord[] = [];
   const missingManual: GameRecord[] = [];
   const onlineNoKernelInfo: GameRecord[] = [];
+  const onlineAcUnknown: GameRecord[] = [];
 
   const NOW = Date.now();
   const STALE_DAYS = 30;
@@ -54,8 +57,15 @@ function gatherIssues(records: GameRecord[]): IssueGroup[] {
       missingManual.push(r);
     }
 
-    if (r.type_game === "online" && r.is_kernel_ac == null && (r.anti_cheat ?? "-") !== "-") {
+    const ac = (r.anti_cheat ?? "").trim();
+    const acIsBlank = ac === "" || ac === "-";
+
+    if (r.type_game === "online" && r.is_kernel_ac == null && !acIsBlank) {
       onlineNoKernelInfo.push(r);
+    }
+
+    if (r.type_game === "online" && acIsBlank) {
+      onlineAcUnknown.push(r);
     }
   }
 
@@ -64,11 +74,13 @@ function gatherIssues(records: GameRecord[]): IssueGroup[] {
     { key: "Stale", records: stale, icon: Calendar, variant: "warning" },
     { key: "Missing", records: missingManual, icon: AlertTriangle, variant: "warning" },
     { key: "Kernel", records: onlineNoKernelInfo, icon: HeartPulse, variant: "secondary" },
+    { key: "OnlineAcUnknown", records: onlineAcUnknown, icon: ShieldQuestion, variant: "warning" },
   ];
 }
 
 export function HealthPage() {
   const { t } = useTranslation();
+  useDocumentTitle("health.title");
   const q = useGames();
   const auth = useAuth();
   const [busy, setBusy] = useState<string | null>(null);
@@ -201,6 +213,15 @@ export function HealthPage() {
             busy={busy}
             disabled={!auth.isAuthenticated}
             onClick={() => trigger("health.triggerTopOnline", "top-online.yml")}
+          />
+          <TriggerButton
+            label={t("health.triggerTopOffline")}
+            description={t("health.triggerTopOfflineDesc")}
+            file="top-offline.yml"
+            icon={Trophy}
+            busy={busy}
+            disabled={!auth.isAuthenticated}
+            onClick={() => trigger("health.triggerTopOffline", "top-offline.yml")}
           />
           <TriggerButton
             label={t("health.triggerCheckLinks")}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { GpgPanel } from "../components/auth/GpgPanel";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { useAuth } from "../stores/auth";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { getRateLimit, type RateLimit } from "../lib/github-api";
 import { formatNumber } from "../lib/utils";
 import {
@@ -23,6 +24,7 @@ const LANG_LABELS: Record<SupportedLanguage, { native: string; en: string; flag:
 
 export function SettingsPage() {
   const { t, i18n } = useTranslation();
+  useDocumentTitle("settings.title");
   const auth = useAuth();
   const [rate, setRate] = useState<RateLimit | null>(null);
   const [lang, setLang] = useState<SupportedLanguage>(currentLanguage());

--- a/web/src/pages/TopOnline.tsx
+++ b/web/src/pages/TopOnline.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../hooks/useGames";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { TopOnlineBar } from "../components/charts/TopOnlineBar";
 import { LoadingState, ErrorState } from "../components/common/QueryState";
 
 export function TopOnlinePage() {
   const { t } = useTranslation();
+  useDocumentTitle("topOnline.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/AntiCheat.tsx
+++ b/web/src/pages/charts/AntiCheat.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { AntiCheatStacked } from "../../components/charts/AntiCheatStacked";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function AntiCheatPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.antiCheat.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Drm.tsx
+++ b/web/src/pages/charts/Drm.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { DrmDlcBars } from "../../components/charts/DrmDlcBars";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function DrmPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.drm.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Genres.tsx
+++ b/web/src/pages/charts/Genres.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { GenreTreemap } from "../../components/charts/GenreTreemap";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function GenresPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.genres.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Languages.tsx
+++ b/web/src/pages/charts/Languages.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { LanguagesHeatmap } from "../../components/charts/LanguagesHeatmap";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function LanguagesPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.languages.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Platforms.tsx
+++ b/web/src/pages/charts/Platforms.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { PlatformsDonut } from "../../components/charts/PlatformsDonut";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function PlatformsPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.platforms.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Players.tsx
+++ b/web/src/pages/charts/Players.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { PlayerTiersPie } from "../../components/charts/PlayerTiersPie";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function PlayersPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.players.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Reviews.tsx
+++ b/web/src/pages/charts/Reviews.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { ReviewsHistogram } from "../../components/charts/ReviewsHistogram";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function ReviewsPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.reviews.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Tags.tsx
+++ b/web/src/pages/charts/Tags.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { TagsWordCloud } from "../../components/charts/TagsWordCloud";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function TagsPage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.tags.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;

--- a/web/src/pages/charts/Time.tsx
+++ b/web/src/pages/charts/Time.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useGames } from "../../hooks/useGames";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import { ReleaseYearHistogram } from "../../components/charts/ReleaseYearHistogram";
 import { AddedCumulativeLine } from "../../components/charts/AddedCumulativeLine";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
@@ -7,6 +8,7 @@ import { LoadingState, ErrorState } from "../../components/common/QueryState";
 
 export function TimePage() {
   const { t } = useTranslation();
+  useDocumentTitle("charts.time.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;


### PR DESCRIPTION
## Summary

Bundles 8 features for v3.2.0 per the planning round (`spec.txt` + `username.txt` reference, plus optional tasks 7 & 8 enabled).

| # | Feature | Files |
|---|---------|-------|
| 1 | **SEO basics** — OG / Twitter Card / canonical / JSON-LD in `index.html`; `robots.txt` + `sitemap.xml`; `useDocumentTitle` hook wired into all 18 pages so the tab title reflects route + language | [web/index.html](../blob/main/web/index.html), [web/public/](../tree/main/web/public), [web/src/hooks/useDocumentTitle.ts](../blob/main/web/src/hooks/useDocumentTitle.ts) |
| 2 | **Auto-post Discussion on release** — `release: published` + `workflow_dispatch`, GraphQL `createDiscussion`, idempotent (skip on duplicate title), prefers `Announcements` category with fallback to `General` | [.github/workflows/announce-release-discussion.yml](../blob/main/.github/workflows/announce-release-discussion.yml) |
| 3 | **Dev docs** — `docs/pc_spec.md`, `docs/dev_env.md`, VI mirrors under `docs/i18n/vi/`, `web/src-tauri/TAURI.md` (build prerequisites + signing). `AUTHORS.md` gets a Dev info table | [docs/](../tree/main/docs), [web/src-tauri/TAURI.md](../blob/main/web/src-tauri/TAURI.md) |
| 4 | **Donate page** at `/donate` with 5 platform cards (GitHub Sponsors / Ko-fi / BMC / Patreon / PayPal) sourced from `.github/FUNDING.yml`. New nav item, EN + VI i18n keys | [web/src/pages/Donate.tsx](../blob/main/web/src/pages/Donate.tsx) |
| 5 | **Telegram bot user guide** — new `docs/telegram-bot.md` pointer to external `USER_GUIDE.md`. CONTRIBUTING.md + About page link the same | [docs/telegram-bot.md](../blob/main/docs/telegram-bot.md), [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) |
| 6 | **Health bucket split** — separates "Online + AC + kernel unknown" from "Online · anti-cheat unknown / none" so games with empty `anti_cheat` are no longer hidden | [web/src/pages/Health.tsx](../blob/main/web/src/pages/Health.tsx) |
| 7 | **Steam Desktop direct link** — game detail drawer renders 2 buttons: `steam://store/<appid>` + `https://store.steampowered.com/app/<appid>/`. Web users with Steam installed get the native flow; rest fall back to browser | [web/src/lib/steam-link.ts](../blob/main/web/src/lib/steam-link.ts), [web/src/components/games/GameDetailDrawer.tsx](../blob/main/web/src/components/games/GameDetailDrawer.tsx) |
| 8 | **Bi-weekly offline player leaderboard** — `top_offline.py` + `bash/offline.sh` + workflow (cron 1st + 15th of each month + `workflow_dispatch`). Output: `games/top-offline.md` (top 100 single-player concurrents). Health page gets a manual trigger | [scripts/top_offline.py](../blob/main/scripts/top_offline.py), [.github/workflows/top-offline.yml](../blob/main/.github/workflows/top-offline.yml) |

Locked-in decisions (from planning):
- Donate UI → page riêng `/donate` (5 cards)
- Discussion category → `Announcements` (fallback `General`)
- Optional 7 + 8 → both included
- Steam Desktop → 2 buttons on web AND Tauri

## Test plan

- [x] `cd web && npm run typecheck` passes
- [x] `cd web && npm run build` passes (PWA emits 17 precache entries, manifest.webmanifest generated)
- [ ] Smoke /donate route → 5 cards open correct external URLs in new tab
- [ ] Switch EN ↔ VI → tab title + Donate labels update live
- [ ] /health → 5th card "Online · anti-cheat unknown / none" appears
- [ ] Game detail drawer → click "Steam Desktop" with Steam installed → opens client; click "Web" → opens store page
- [ ] Run `gh workflow run announce-release-discussion.yml -f tag=desktop-v1.1.0` → Discussion appears in Announcements
- [ ] Re-run same command → idempotent skip with notice
- [ ] Run `gh workflow run top-offline.yml` → `games/top-offline.md` committed by `github-actions[bot]`
- [ ] Lighthouse SEO score on the deployed Pages site ≥ 90
- [ ] Open Graph preview via opengraph.xyz looks correct

## Notes

- Built on top of the worktree branch `claude/tender-stonebraker-fd9d63`. 43 files changed, 1131 insertions, 16 deletions.
- `package-lock.json` version bump from 1.0.0 → 1.1.0 is incidental (matches `tauri.conf.json` already at 1.1.0).
- Per the spec.txt note about `webapp/TAURI.md`: actual Tauri config lives at `web/src-tauri/`, so the docs file was created there (not under a new `webapp/` folder) — the README docs section now links the right path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)