### PR TITLE
Fix Ctrl+K palette, Health filter, Tauri singleton, type_game inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.2.2] – 2026-05-11 (The "Bug Fix Quartet" Edition)
+
+Patch release on top of v3.2.1. Four user-reported bug fixes touching the Ctrl+K command palette on desktop, the Health → Games navigation flow, Tauri process-stacking on every launch, and the `type_game` scraper that was defaulting every new game to `"offline"`. Web app + desktop bumped `1.2.1` → `1.2.2`. Repo public-facing version `3.2.1` → `3.2.2`. Tag `v3.2.2` is GPG-signed; companion desktop tag is `desktop-v1.2.2`.
+
+### 🔗 Desktop Ctrl+K external link
+
+- New `web/src/lib/external-open.ts` — lazy-detects the Tauri runtime via `__TAURI_INTERNALS__`, opens external URLs through `@tauri-apps/plugin-shell` on desktop (capability `shell:allow-open` already granted in `web/src-tauri/capabilities/default.json`), falls back to `window.open(url, "_blank", "noopener,noreferrer")` on web/PWA. Plugin module is lazy-imported, so the web bundle never pays for the Tauri code path.
+- `web/src/components/common/CommandPalette.tsx` — Ctrl+K game results now route through `openExternal()`. The Tauri webview was silently blocking the raw `window.open(r.link, "_blank")` for external HTTPS URLs, so clicking a search result on desktop did nothing.
+- Six other `window.open(...)` call sites (Health workflow link, Add, BulkActionBar, BulkEditDrawer, EditGameDrawer, DeviceFlowPanel) are flagged for follow-up migration to `openExternal()` — same desktop silent-fail will hit them when triggered.
+
+### 🩺 Health → Games filter restoration
+
+- `web/src/pages/Games.tsx` — adds `useSearchParams` + a `useEffect` that mirrors the URL `?search=` parameter into `useFilters.search` on mount. The Health page already linked rows to `#/games?search=<name>`, but Games never read the param, so the table stayed unfiltered and the Topbar input stayed empty. The store binding to Topbar means visual feedback is automatic once the filter is set.
+- Guard `if (term !== null)` (instead of `if (term)`) lets `?search=` explicitly clear the filter — useful for shareable "no filter" links.
+
+### 🪟 Tauri single-instance enforcement
+
+- `web/src-tauri/Cargo.toml` — adds `tauri-plugin-single-instance = "2"` under the existing desktop-only `cfg(not(any(target_os = "android", target_os = "ios")))` block, matching the updater plugin's gating pattern.
+- `web/src-tauri/src/lib.rs` — registers single-instance as the **first** plugin so it short-circuits duplicate launches before any other state initialises. The dup-launch callback calls `unminimize()` + `show()` + `set_focus()` on the existing `main` window. Without this, every Start-menu / shortcut / file-association invocation spawned a fresh `f2p-tracker.exe` that lingered in Task Manager.
+- No capability changes needed — plugin runs entirely Rust-side, no frontend command exposed.
+
+### 🎮 `type_game` online inference
+
+- `scripts/core/fetcher.py` — new `_infer_type_game(categories)` reads `data.get("categories", [])` and returns `"online"` when any description contains `online`, `mmo`, `massively multiplayer`, `cross-platform multiplayer`, or `multi-player`. Pure `shared/split screen` descriptions are treated as local-only and skipped unless paired with another online signal.
+- Wired into `apply_details()` next to the existing anti-cheat category loop, guarded by `is_empty(game.get("type_game"))` so manual prefills in `temp_info.jsonl` remain authoritative — the `MANUAL_FIELDS` merge in `data_store.merge_extension_data()` and the override re-apply in `ingest_new.py` are unchanged.
+- The legacy default-to-`"offline"` at the end of `fetch_full()` stays as the final safety net for games with no multiplayer signal in Steam categories. New ingests of online F2P games now classify correctly instead of all-offline.
+
 ## [v3.2.1] – 2026-05-11 (The "Genre Cleanup" Edition)
 
 Patch release on top of v3.2.0. Normalizes inconsistent `genre` values across the dataset (31 records, 10 canonical mappings) and broadens the webapp's genre combobox with 14 additional suggestions. Web app + desktop bumped `1.2.0` → `1.2.1`. Repo public-facing version `3.2.0` → `3.2.1`. Tag `v3.2.1` is GPG-signed; companion desktop tag is `desktop-v1.2.1`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.2.1-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.2.2-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)

--- a/scripts/core/fetcher.py
+++ b/scripts/core/fetcher.py
@@ -19,6 +19,37 @@ from .data_store import extract_appid, now_iso, is_info_complete, is_empty
 from .scraper import scrape_store_page
 
 
+# Steam category descriptions that imply online multiplayer. Bias toward
+# "online" only when the signal is clear (Online PvP, MMO, Cross-Platform
+# Multiplayer, etc.). Pure "Shared/Split Screen" games fall through to the
+# empty default and become "offline" at the end of fetch_full.
+_ONLINE_CATEGORY_TOKENS = (
+    "online",                       # Online PvP, Online Co-op, etc.
+    "mmo",
+    "massively multiplayer",
+    "cross-platform multiplayer",
+    "multi-player",                 # Steam's catch-all multiplayer tag
+)
+_LOCAL_ONLY_TOKENS = ("shared/split screen",)
+
+
+def _infer_type_game(categories: list[dict]) -> str:
+    """Return 'online' if any category signals online multiplayer, else ''
+    (caller falls back to 'offline'). Local-only signals are ignored unless
+    paired with an online signal in another category."""
+    for cat in categories:
+        desc = (cat.get("description") or "").lower()
+        if not desc:
+            continue
+        if any(tok in desc for tok in _LOCAL_ONLY_TOKENS) and not any(
+            tok in desc for tok in ("online", "mmo", "cross-platform")
+        ):
+            continue
+        if any(tok in desc for tok in _ONLINE_CATEGORY_TOKENS):
+            return "online"
+    return ""
+
+
 # ──────────── Apply functions ────────────
 
 def apply_details(game: dict, data: dict) -> dict:
@@ -73,6 +104,14 @@ def apply_details(game: dict, data: dict) -> dict:
                     break
             if game["anti_cheat"] != "-":
                 break
+
+    # Infer type_game from categories when not manually set. Manual prefills
+    # win because MANUAL_FIELDS gates the merge in merge_extension_data(),
+    # and ingest_new.py re-applies overrides after fetch_full.
+    if is_empty(game.get("type_game")):
+        inferred = _infer_type_game(data.get("categories", []))
+        if inferred:
+            game["type_game"] = inferred
 
     # Metacritic
     mc = data.get("metacritic", {})

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -57,6 +57,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +280,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -329,6 +473,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -723,6 +876,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,14 +930,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "f2p-tracker"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
 ]
 
@@ -898,6 +1100,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1263,6 +1478,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2211,6 +2432,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2489,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2354,6 +2591,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,6 +2650,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3538,6 +3800,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3983,7 +4260,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4034,6 +4323,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5104,6 +5404,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5180,3 +5541,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.2",
+]

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -36,12 +36,13 @@ serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 
-# Auto-updater is desktop-only — Tauri itself rejects the plugin on mobile
-# at compile time, so we gate the dep behind cfg(not(any(target_os="ios",
-# target_os="android"))) inside lib.rs and only depend on it for desktop
-# targets here.
+# Auto-updater and single-instance plugins are desktop-only — Tauri rejects
+# both at compile time on mobile, so we gate the deps behind
+# cfg(not(any(target_os="ios", target_os="android"))) inside lib.rs and only
+# depend on them for desktop targets here.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
+tauri-plugin-single-instance = "2"
 
 [features]
 # DO NOT REMOVE: feature flags consumed by the bundled tauri build.

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.2.1"
+version = "1.2.2"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -3,7 +3,29 @@
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let mut builder = tauri::Builder::default().plugin(tauri_plugin_shell::init());
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance MUST be the first plugin so it can short-circuit a
+    // duplicate launch before any other state initialises. Without this, each
+    // Start-menu / shortcut invocation spawns a separate process that stays
+    // resident — Task Manager grew an extra `f2p-tracker.exe` per launch.
+    // Desktop-only: the plugin isn't published for iOS / Android, matching
+    // the updater gating below and in Cargo.toml.
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    {
+        use tauri::Manager;
+        builder = builder.plugin(tauri_plugin_single_instance::init(
+            |app, _args, _cwd| {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.unminimize();
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            },
+        ));
+    }
+
+    builder = builder.plugin(tauri_plugin_shell::init());
 
     // The updater plugin only ships on desktop. Tauri rejects it at compile
     // time for iOS / Android, and we gate the Cargo dep the same way in

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/components/common/CommandPalette.tsx
+++ b/web/src/components/common/CommandPalette.tsx
@@ -27,6 +27,7 @@ import {
 import { useGames } from "../../hooks/useGames";
 import { useGpg } from "../../stores/gpg";
 import { headerToCapsule } from "../../lib/image";
+import { openExternal } from "../../lib/external-open";
 import "./command-palette.css";
 
 interface NavCmd {
@@ -180,7 +181,7 @@ export function CommandPalette() {
                   <Command.Item
                     key={r.link}
                     onSelect={() => {
-                      window.open(r.link, "_blank");
+                      void openExternal(r.link);
                       setOpen(false);
                     }}
                     className="cmdk-item"

--- a/web/src/lib/external-open.ts
+++ b/web/src/lib/external-open.ts
@@ -1,0 +1,30 @@
+// Open an external URL. On Tauri desktop, window.open() to an external
+// HTTP(S) URL is blocked by the webview, so route through the shell plugin.
+// Web/PWA path keeps the legacy behaviour (no Tauri import in the web bundle
+// — the plugin module is lazy-imported only when we detect the Tauri runtime).
+
+interface TauriRuntime extends Window {
+  __TAURI_INTERNALS__?: unknown;
+}
+
+function isTauri(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    !!(window as TauriRuntime).__TAURI_INTERNALS__
+  );
+}
+
+export async function openExternal(url: string): Promise<void> {
+  if (isTauri()) {
+    try {
+      const { open } = await import("@tauri-apps/plugin-shell");
+      await open(url);
+      return;
+    } catch (err) {
+      // Fall through to window.open as a last resort. The Tauri webview will
+      // likely block it, but we surface the error so triage isn't silent.
+      console.error("openExternal: shell plugin failed, falling back", err);
+    }
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/web/src/pages/Games.tsx
+++ b/web/src/pages/Games.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useGames } from "../hooks/useGames";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { GamesTable } from "../components/games/GamesTable";
@@ -17,6 +17,8 @@ export function GamesPage() {
   const q = useGames();
   const navigate = useNavigate();
   const { appid } = useParams<{ appid: string }>();
+  const [searchParams] = useSearchParams();
+  const setSearch = useFilters((s) => s.setSearch);
   const genre = useFilters((s) => s.genre);
   const setGenre = useFilters((s) => s.setGenre);
   const typeGame = useFilters((s) => s.type_game);
@@ -44,6 +46,14 @@ export function GamesPage() {
       platforms: Array.from(platforms.entries()).sort((a, b) => b[1] - a[1]),
     };
   }, [q.data]);
+
+  // Sync ?search= URL param into the global filter store. Health page links
+  // arrive at #/games?search=Foo expecting the Topbar input + GamesTable to
+  // filter to Foo. Without this effect the param is silently ignored.
+  useEffect(() => {
+    const term = searchParams.get("search");
+    if (term !== null) setSearch(term);
+  }, [searchParams, setSearch]);
 
   if (q.isLoading) return <LoadingState />;
   if (q.error) return <ErrorState error={q.error} />;


### PR DESCRIPTION
## Summary

Bốn bug-fix do user báo:

- **Bug 1 — Ctrl+K palette không phản hồi trên desktop.** [CommandPalette.tsx](web/src/components/common/CommandPalette.tsx) dùng `window.open(r.link, "_blank")` để mở Steam — Tauri webview chặn `window.open` cho external HTTPS. Tạo helper [external-open.ts](web/src/lib/external-open.ts) detect Tauri runtime và route qua `@tauri-apps/plugin-shell` (`shell:allow-open` capability đã có sẵn). Web vẫn dùng `window.open` như cũ — bundle web không cost gì thêm vì plugin shell được lazy-import.

- **Bug 2 — Health → Games không filter.** [Health.tsx:159](web/src/pages/Health.tsx#L159) link tới `#/games?search=<name>` nhưng [Games.tsx](web/src/pages/Games.tsx) không đọc URL param. Thêm `useSearchParams` + `useEffect` mirror `?search=` vào `useFilters.search` store; Topbar input đã bind vào store nên tự fill tên game.

- **Bug 3 — Tauri process accumulation.** Mỗi lần mở app +1 process do không có single-instance plugin. Thêm `tauri-plugin-single-instance` (desktop-only, gate `cfg(not(any(target_os="android",target_os="ios")))` giống updater). Lần invocation thứ 2 sẽ `unminimize` + `show` + `set_focus` window đang chạy thay vì spawn process mới.

- **Bug 4 — `type_game` luôn `"offline"`.** [fetcher.py:197](scripts/core/fetcher.py#L197) hardcode default; scraper không infer. Thêm helper `_infer_type_game()` đọc Steam categories (`Online PvP`, `MMO`, `Cross-Platform Multiplayer`, `Multi-player`…) → set `"online"` khi `type_game` rỗng. Manual prefill trong `temp_info.jsonl` vẫn thắng vì `MANUAL_FIELDS` merge ([data_store.py:286-289](scripts/core/data_store.py#L286-L289)) và override re-apply ([ingest_new.py:85-94](scripts/ingest_new.py#L85-L94)) không thay đổi. Default `"offline"` ở cuối `fetch_full` giữ làm fallback.

## Test plan

- [ ] `npm run tauri:dev`, Ctrl+K, gõ tên game ≥ 2 ký tự, Enter → trình duyệt mặc định mở Steam store
- [ ] `npm run dev` (web), cùng thao tác → mở tab mới như cũ (regression check)
- [ ] Trên Health page → click 1 tên game → URL = `#/games?search=<Name>`, Topbar hiện `<Name>`, GamesTable filter còn match
- [ ] Refresh tại URL `#/games?search=<Name>` → filter giữ nguyên
- [ ] `npm run tauri:build` → no compile error; launch `.exe` 2 lần liên tiếp → Task Manager chỉ 1 process, window cũ focus
- [ ] Add 3 games test (online MMO, split-screen co-op only, single-player) qua `temp_info.jsonl` với `type_game` rỗng → ingest → kiểm tra shard: MMO `"online"`, 2 cái còn lại `"offline"`
- [ ] Regression manual prefill: pre-set `type_game="offline"` cho 1 game thực sự online → ingest → value giữ `"offline"`

## Out of scope (follow-up)

6 callers `window.open` khác trong web app (`Health.tsx`, `Add.tsx`, `BulkActionBar.tsx`, `BulkEditDrawer.tsx`, `EditGameDrawer.tsx`, `DeviceFlowPanel.tsx`) cũng sẽ silent fail trên desktop. Helper `openExternal()` đã sẵn — migrate 1 dòng/caller trong PR riêng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)