### PR TITLE
v3.2.3: View commit toast fix, offline AC lock, mark-dead-games workflow

### DIFF
--- a/.github/workflows/mark-dead-games.yml
+++ b/.github/workflows/mark-dead-games.yml
@@ -33,9 +33,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: scripts/requirements.txt
+          cache-dependency-path: requirements.txt
 
-      - run: pip install -r scripts/requirements.txt
+      - run: pip install -r requirements.txt
 
       - name: Mark dead games
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.2.3] – 2026-05-17 (The "View Commit Toast + Offline AC Lock" Edition)
+
+Patch release on top of v3.2.2. Three user-reported fixes: the "View commit" action button in success toasts (now reachable + cross-platform), an editor lock that prevents anti-cheat fields from being set on offline games, and a broken `Mark dead games` workflow setup-python step. Web app + desktop bumped `1.2.2` → `1.2.3`. Repo public-facing version `3.2.2` → `3.2.3`. Tag `v3.2.3` is GPG-signed; companion desktop tag is `desktop-v1.2.3`.
+
+### 🍞 View commit toast — clickable + desktop-safe
+
+- Migrated the eight `window.open(commit.htmlUrl, "_blank")` action handlers in `EditGameDrawer.tsx` (2), `Add.tsx` (2 inside `reportToast`), `BulkEditDrawer.tsx` (2), and `BulkActionBar.tsx` (2) to `openExternal()` from `web/src/lib/external-open.ts` — completes the follow-up migration flagged in v3.2.2's CHANGELOG. The Tauri webview was silently blocking the raw `window.open(...)` for external HTTPS URLs, so "View commit" did nothing on desktop.
+- Each `toast.success(...)` with a "View commit" action now sets `duration: 15000` (was Sonner's 4 s default). On web the old toasts auto-dismissed before the user could read the description + click the action button.
+- Handler now accepts the click event and calls `event.preventDefault()` so the toast stays visible after click (Sonner's default is to dismiss on action click — undesirable when the user wants to glance at the SHA after opening the commit).
+- The fix applies to both the initial `toast.success` and the follow-up emit fired by `pollCommitVerification(...).then(...)` (same toast `id`, so `duration` must be set on the update too — otherwise the second emit rebounds to the 4 s default).
+
+### 🔒 Anti-cheat fields lock on offline games
+
+- `web/src/components/games/EditGameDrawer.tsx` — `FormFields` derives `lockAC = form.type_game === "offline"` and threads `disabled={lockAC}` to the AC `<select>`, the custom-AC `<Input>`, the three kernel `<Button>`s, and the AC note `<Textarea>`. A muted hint is rendered under the AC note when locked, explaining how to re-enable.
+- `update()` setter now auto-resets `anti_cheat=""`, `anti_cheat_note=""`, `is_kernel_ac="unknown"` when `key === "type_game" && value === "offline"`. This keeps the `formToPatch()` diff honest — switching an online game with AC populated to offline now produces an explicit AC-clear in the commit instead of orphan anti-cheat data on an offline record.
+- `web/src/pages/Add.tsx` — same pattern in `OverrideFields` + the `SingleAdd.setOv()` setter. `OverrideFields` combines the existing busy-state `disabled` prop with the new lock via `acDisabled = disabled || lockAC`, so the global "form is submitting" disable still wins. BulkAdd uses raw text / JSON input, so no UI lock needed there.
+- `type_game === ""` (unknown) deliberately does **not** lock — only an explicit `"offline"` triggers the gate. The existing `validation.ts` "kernel?" badge rule for online + missing-kernel is untouched.
+- New i18n key `edit.acLockedOffline` added to `web/src/i18n/locales/en.json` and `vi.json`, rendered as a `text-xs text-muted-foreground` hint under the AC note when `lockAC` is true.
+
+### 🪦 `Mark dead games` workflow path fix
+
+- `.github/workflows/mark-dead-games.yml` — `cache-dependency-path: scripts/requirements.txt` and the subsequent `pip install -r scripts/requirements.txt` both pointed at a path that doesn't exist. The file lives at the repo root (`requirements.txt`), consistent with the path `codeql.yml:25` already uses.
+- Fix: both lines now reference `requirements.txt` at the root. The `setup-python` cache lookup no longer errors with `No file in /home/runner/work/free-steam-games-list/free-steam-games-list matched to [scripts/requirements.txt or **/pyproject.toml]`, and the install step actually finds the deps.
+- Workflow is scheduled Mon + Thu 04:30 UTC; the next scheduled run will be the first end-to-end verification, but `workflow_dispatch` with `dry_run=true` is also available for ad-hoc validation.
+
 ## [v3.2.2] – 2026-05-11 (The "Bug Fix Quartet" Edition)
 
 Patch release on top of v3.2.1. Four user-reported bug fixes touching the Ctrl+K command palette on desktop, the Health → Games navigation flow, Tauri process-stacking on every launch, and the `type_game` scraper that was defaulting every new game to `"offline"`. Web app + desktop bumped `1.2.1` → `1.2.2`. Repo public-facing version `3.2.1` → `3.2.2`. Tag `v3.2.2` is GPG-signed; companion desktop tag is `desktop-v1.2.2`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.2.2-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.2.3-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.2.2"
+version = "1.2.3"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/components/games/BulkActionBar.tsx
+++ b/web/src/components/games/BulkActionBar.tsx
@@ -21,6 +21,7 @@ import { useIsOwner } from "../../hooks/useIsOwner";
 import { bulkDeleteGames } from "../../lib/edits";
 import { optimisticBulkDelete } from "../../lib/optimistic";
 import { pollCommitVerification } from "../../lib/verify-commit";
+import { openExternal } from "../../lib/external-open";
 import { BulkEditDrawer } from "./BulkEditDrawer";
 
 interface Props {
@@ -79,24 +80,32 @@ export function BulkActionBar({ visibleAppids }: Props) {
       const sevenSha = result.commit.sha.slice(0, 7);
       toast.success(t("games.deletedToast", { count: result.removed }), {
         id: toastId,
+        duration: 15000,
         description: ctx.willSign
           ? `${sevenSha} · ${t("common.verifying")}`
           : `${sevenSha} · ${t("games.unsigned")}`,
         action: {
           label: t("verify.viewCommit"),
-          onClick: () => window.open(result.commit.htmlUrl, "_blank"),
+          onClick: (event) => {
+            event.preventDefault();
+            void openExternal(result.commit.htmlUrl);
+          },
         },
       });
       if (ctx.willSign) {
         void pollCommitVerification(result.commit.sha, auth.token).then((v) => {
           toast.success(t("games.deletedToast", { count: result.removed }), {
             id: toastId,
+            duration: 15000,
             description: v.verified
               ? `${sevenSha} · ${t("verify.verified")}`
               : `${sevenSha} · ${t("verify.unverifiedReason", { reason: v.reason })}`,
             action: {
               label: t("verify.viewCommit"),
-              onClick: () => window.open(result.commit.htmlUrl, "_blank"),
+              onClick: (event) => {
+                event.preventDefault();
+                void openExternal(result.commit.htmlUrl);
+              },
             },
           });
         });

--- a/web/src/components/games/BulkEditDrawer.tsx
+++ b/web/src/components/games/BulkEditDrawer.tsx
@@ -22,6 +22,7 @@ import { useCommitContext } from "../../hooks/useCommitContext";
 import { bulkEditGames, type EditPatch } from "../../lib/edits";
 import { optimisticBulkEdit } from "../../lib/optimistic";
 import { pollCommitVerification } from "../../lib/verify-commit";
+import { openExternal } from "../../lib/external-open";
 import {
   ANTI_CHEAT_ENUM,
   GENRE_ENUM,
@@ -138,24 +139,32 @@ export function BulkEditDrawer({ appids, onClose, onCommitted }: Props) {
       const shardsLabel = t("bulk.shardsLabel", { count: result.shardsTouched.length });
       toast.success(t("bulk.bulkEditedToast", { count: result.modified }), {
         id: toastId,
+        duration: 15000,
         description: ctx.willSign
           ? `${sevenSha} · ${shardsLabel} · ${t("common.verifying")}`
           : `${sevenSha} · ${shardsLabel} · ${t("games.unsigned")}`,
         action: {
           label: t("verify.viewCommit"),
-          onClick: () => window.open(result.commit.htmlUrl, "_blank"),
+          onClick: (event) => {
+            event.preventDefault();
+            void openExternal(result.commit.htmlUrl);
+          },
         },
       });
       if (ctx.willSign) {
         void pollCommitVerification(result.commit.sha, auth.token).then((v) => {
           toast.success(t("bulk.bulkEditedToast", { count: result.modified }), {
             id: toastId,
+            duration: 15000,
             description: v.verified
               ? `${sevenSha} · ${shardsLabel} · ${t("verify.verified")}`
               : `${sevenSha} · ${shardsLabel} · ${t("verify.unverifiedReason", { reason: v.reason })}`,
             action: {
               label: t("verify.viewCommit"),
-              onClick: () => window.open(result.commit.htmlUrl, "_blank"),
+              onClick: (event) => {
+                event.preventDefault();
+                void openExternal(result.commit.htmlUrl);
+              },
             },
           });
         });

--- a/web/src/components/games/EditGameDrawer.tsx
+++ b/web/src/components/games/EditGameDrawer.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../lib/edits";
 import { optimisticEdit, optimisticReplace } from "../../lib/optimistic";
 import { pollCommitVerification } from "../../lib/verify-commit";
+import { openExternal } from "../../lib/external-open";
 import {
   ANTI_CHEAT_ENUM,
   GENRE_ENUM,
@@ -195,7 +196,16 @@ export function EditGameDrawer({ game, onClose }: Props) {
   }
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
-    setForm((f) => (f ? { ...f, [key]: value } : f));
+    setForm((f) => {
+      if (!f) return f;
+      const next = { ...f, [key]: value };
+      if (key === "type_game" && value === "offline") {
+        next.anti_cheat = "";
+        next.anti_cheat_note = "";
+        next.is_kernel_ac = "unknown";
+      }
+      return next;
+    });
   }
 
   async function save() {
@@ -250,12 +260,16 @@ export function EditGameDrawer({ game, onClose }: Props) {
       const sevenSha = commit.sha.slice(0, 7);
       toast.success(t("edit.savedToast", { sha: sevenSha }), {
         id: toastId,
+        duration: 15000,
         description: ctx.willSign
           ? `${shard} · ${t("common.verifying")}`
           : `${shard} · ${t("games.unsigned")}`,
         action: {
           label: t("verify.viewCommit"),
-          onClick: () => window.open(commit.htmlUrl, "_blank"),
+          onClick: (event) => {
+            event.preventDefault();
+            void openExternal(commit.htmlUrl);
+          },
         },
       });
 
@@ -264,12 +278,16 @@ export function EditGameDrawer({ game, onClose }: Props) {
         void pollCommitVerification(commit.sha, auth.token).then((v) => {
           toast.success(t("edit.savedToast", { sha: sevenSha }), {
             id: toastId,
+            duration: 15000,
             description: v.verified
               ? `${shard} · ${t("verify.verified")}`
               : `${shard} · ${t("verify.unverifiedReason", { reason: v.reason })}`,
             action: {
               label: t("verify.viewCommit"),
-              onClick: () => window.open(commit.htmlUrl, "_blank"),
+              onClick: (event) => {
+                event.preventDefault();
+                void openExternal(commit.htmlUrl);
+              },
             },
           });
         });
@@ -453,6 +471,7 @@ interface FormFieldsProps {
 function FormFields({ form, update }: FormFieldsProps) {
   const { t } = useTranslation();
   const isCustomAC = !(ANTI_CHEAT_ENUM as readonly string[]).includes(form.anti_cheat);
+  const lockAC = form.type_game === "offline";
   return (
     <>
       <div className="grid gap-3 sm:grid-cols-2">
@@ -499,7 +518,8 @@ function FormFields({ form, update }: FormFieldsProps) {
               if (e.target.value === "__custom__") update("anti_cheat", "");
               else update("anti_cheat", e.target.value);
             }}
-            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+            disabled={lockAC}
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {ANTI_CHEAT_ENUM.map((a) => (
               <option key={a} value={a}>
@@ -512,6 +532,7 @@ function FormFields({ form, update }: FormFieldsProps) {
             <Input
               value={form.anti_cheat}
               onChange={(e) => update("anti_cheat", e.target.value)}
+              disabled={lockAC}
               placeholder={t("add.customAcName")}
               className="mt-1"
             />
@@ -528,6 +549,7 @@ function FormFields({ form, update }: FormFieldsProps) {
                 size="sm"
                 variant={form.is_kernel_ac === v ? "default" : "outline"}
                 onClick={() => update("is_kernel_ac", v)}
+                disabled={lockAC}
               >
                 {t(`common.${v}`)}
               </Button>
@@ -542,9 +564,15 @@ function FormFields({ form, update }: FormFieldsProps) {
           id="anti_cheat_note"
           value={form.anti_cheat_note}
           onChange={(e) => update("anti_cheat_note", e.target.value)}
+          disabled={lockAC}
           placeholder={t("edit.antiCheatNotePlaceholder")}
           rows={2}
         />
+        {lockAC && (
+          <p className="text-xs text-muted-foreground">
+            {t("edit.acLockedOffline")}
+          </p>
+        )}
       </div>
 
       <div className="space-y-1.5">

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -145,7 +145,8 @@
     "notesPlaceholder": "Personal review or comment",
     "jsonPowerMode": "Power-user mode: replaces the entire record. {{addedAt}} is preserved from the original; everything else is committed verbatim.",
     "noValidJsonDiff": "No valid JSON to diff.",
-    "unlockInSettingsLink": "Unlock in Settings"
+    "unlockInSettingsLink": "Unlock in Settings",
+    "acLockedOffline": "Anti-cheat fields are disabled for offline games. Switch type to online to edit."
   },
   "settings": {
     "title": "Settings",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -145,7 +145,8 @@
     "notesPlaceholder": "Đánh giá cá nhân hoặc comment",
     "jsonPowerMode": "Chế độ power-user: thay thế toàn bộ record. {{addedAt}} được giữ từ bản gốc; phần còn lại commit nguyên văn.",
     "noValidJsonDiff": "JSON không hợp lệ để diff.",
-    "unlockInSettingsLink": "Unlock trong Settings"
+    "unlockInSettingsLink": "Unlock trong Settings",
+    "acLockedOffline": "Trường anti-cheat bị khoá cho game offline. Đổi type sang online để chỉnh sửa."
   },
   "settings": {
     "title": "Cài đặt",

--- a/web/src/pages/Add.tsx
+++ b/web/src/pages/Add.tsx
@@ -37,6 +37,7 @@ import { addLinks, type AddEntry } from "../lib/edits";
 import { extractAppid, normalizeLink } from "../lib/data-store";
 import { LoadingState } from "../components/common/QueryState";
 import { pollCommitVerification } from "../lib/verify-commit";
+import { openExternal } from "../lib/external-open";
 import {
   ANTI_CHEAT_ENUM,
   GENRE_ENUM,
@@ -174,24 +175,32 @@ function reportToast(
   const ingestStarting = "ingest starting";
   toast.success(label, {
     id: toastId,
+    duration: 15000,
     description: ctx.willSign
       ? `${sevenSha} · ${t("common.verifying")} · ${ingestStarting}`
       : `${sevenSha} · ${t("games.unsigned")} · ${ingestStarting}`,
     action: {
       label: t("verify.viewCommit"),
-      onClick: () => window.open(result.commit.htmlUrl, "_blank"),
+      onClick: (event) => {
+        event.preventDefault();
+        void openExternal(result.commit.htmlUrl);
+      },
     },
   });
   if (ctx.willSign) {
     void pollCommitVerification(result.commit.sha, token).then((v) => {
       toast.success(label, {
         id: toastId,
+        duration: 15000,
         description: v.verified
           ? `${sevenSha} · ${t("verify.verified")} · ${ingestStarting}`
           : `${sevenSha} · ${t("verify.unverifiedReason", { reason: v.reason })}`,
         action: {
           label: t("verify.viewCommit"),
-          onClick: () => window.open(result.commit.htmlUrl, "_blank"),
+          onClick: (event) => {
+            event.preventDefault();
+            void openExternal(result.commit.htmlUrl);
+          },
         },
       });
     });
@@ -247,7 +256,15 @@ function SingleAdd({ existingAppids, ctx, token, onSuccess }: SubProps) {
   }
 
   function setOv<K extends keyof OverrideState>(k: K, v: OverrideState[K]) {
-    setOverride((s) => ({ ...s, [k]: v }));
+    setOverride((s) => {
+      const next = { ...s, [k]: v };
+      if (k === "type_game" && v === "offline") {
+        next.anti_cheat = "";
+        next.anti_cheat_note = "";
+        next.is_kernel_ac = "unknown";
+      }
+      return next;
+    });
   }
 
   const overrideFieldsCount = Object.values(overrideToFields(override)).filter(
@@ -577,6 +594,8 @@ interface OverrideFieldsProps {
 function OverrideFields({ ov, setOv, disabled }: OverrideFieldsProps) {
   const { t } = useTranslation();
   const isCustomAC = !(ANTI_CHEAT_ENUM as readonly string[]).includes(ov.anti_cheat);
+  const lockAC = ov.type_game === "offline";
+  const acDisabled = disabled || lockAC;
   return (
     <>
       <div className="grid gap-3 sm:grid-cols-2">
@@ -625,8 +644,8 @@ function OverrideFields({ ov, setOv, disabled }: OverrideFieldsProps) {
               if (e.target.value === "__custom__") setOv("anti_cheat", "");
               else setOv("anti_cheat", e.target.value);
             }}
-            disabled={disabled}
-            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+            disabled={acDisabled}
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             <option value="">{t("add.skipOption")}</option>
             {ANTI_CHEAT_ENUM.map((a) => (
@@ -640,7 +659,7 @@ function OverrideFields({ ov, setOv, disabled }: OverrideFieldsProps) {
             <Input
               value={ov.anti_cheat}
               onChange={(e) => setOv("anti_cheat", e.target.value)}
-              disabled={disabled}
+              disabled={acDisabled}
               placeholder={t("add.customAcName")}
               className="mt-1"
             />
@@ -657,7 +676,7 @@ function OverrideFields({ ov, setOv, disabled }: OverrideFieldsProps) {
                 size="sm"
                 variant={ov.is_kernel_ac === v ? "default" : "outline"}
                 onClick={() => setOv("is_kernel_ac", v)}
-                disabled={disabled}
+                disabled={acDisabled}
               >
                 {t(`common.${v}`)}
               </Button>
@@ -689,9 +708,14 @@ function OverrideFields({ ov, setOv, disabled }: OverrideFieldsProps) {
           id="ov-acn"
           value={ov.anti_cheat_note}
           onChange={(e) => setOv("anti_cheat_note", e.target.value)}
-          disabled={disabled}
+          disabled={acDisabled}
           rows={2}
         />
+        {lockAC && (
+          <p className="text-xs text-muted-foreground">
+            {t("edit.acLockedOffline")}
+          </p>
+        )}
       </div>
 
       <div className="space-y-1.5">


### PR DESCRIPTION
## Summary

Patch release on top of v3.2.2 — three user-reported fixes bundled into one PR.

- **🍞 View commit toast** — migrates the eight `window.open(commit.htmlUrl, "_blank")` action handlers (EditGameDrawer ×2, Add ×2, BulkEditDrawer ×2, BulkActionBar ×2) to `openExternal()` from `web/src/lib/external-open.ts`, completing the follow-up flagged in v3.2.2's CHANGELOG. Sets `duration: 15000` on the toast (was Sonner's 4s default — toast was auto-dismissing before users could click). Action handler calls `event.preventDefault()` so the toast persists after click.
- **🔒 Offline AC lock** — `EditGameDrawer` + `Add`'s `OverrideFields` derive `lockAC = type_game === "offline"`, disable the AC select / custom AC input / 3 kernel buttons / AC note textarea, and auto-clear those fields when switching to offline. `type_game === ""` (unknown) deliberately does NOT lock. New i18n key `edit.acLockedOffline` (EN + VI).
- **🪦 Mark dead games workflow** — `cache-dependency-path` + `pip install -r` both referenced `scripts/requirements.txt`, but the file lives at the repo root (`requirements.txt`), consistent with `codeql.yml`. Fixed both lines.

Versions bumped: web/desktop `1.2.2` → `1.2.3`, repo `3.2.2` → `3.2.3`. Companion desktop tag will be `desktop-v1.2.3`.

## Test plan

- [x] `npm run typecheck` (web) passes
- [ ] Dev build (`cd web && npm run dev`): edit a game → switch type online ↔ offline → AC fields disable + clear + hint shows on offline; on online they re-enable
- [ ] Same lock behavior in Add page (single override)
- [ ] Toast "View commit" stays visible after 5s+ and the action button opens GitHub in a new tab (web)
- [ ] Same toast behavior in Tauri desktop (via `openExternal` → shell plugin)
- [ ] `Mark dead games` workflow `workflow_dispatch` with `dry_run=true` completes — setup-python no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)