### PR TITLE
v3.2.6: mobile hotfix — AC Index table scroll + card thumbnail fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.2.6] – 2026-05-20 (The "Mobile Hotfix" Edition)
+
+Hotfix on top of v3.2.5. Two mobile-viewport regressions introduced by the v3.2.5 responsive overhaul. Web app + desktop bumped `1.2.5` → `1.2.6`. Repo public-facing version `3.2.5` → `3.2.6`. Tag `v3.2.6` is GPG-signed; companion desktop tag is `desktop-v1.2.6`.
+
+### 🐛 AC Index table — horizontal scroll on mobile
+
+- `web/src/pages/AntiCheatList.tsx` — the per-family table wrapper was `<div className="overflow-hidden rounded-md border">`. On a 390 px viewport the 5-column table (`# / Game / Genre / Kernel / Players`) is wider than the card, and `overflow-hidden` clipped the right-hand columns with no way to scroll to them.
+- Fix: `overflow-hidden` → `overflow-x-auto`. The table now scrolls horizontally when it exceeds the viewport, and the scrollbar stays hidden when it fits.
+
+### 🖼️ Mobile game cards — thumbnail fallback
+
+- `web/src/components/games/table/MobileGameCards.tsx` — the card `<img>` loads `headerToCapsule(g.header_image)` (the smaller `capsule_184x69.jpg` variant, ~10 KB vs ~50 KB). Steam's CDN doesn't host that variant for every game, so those cards rendered a blank thumbnail.
+- The desktop table column (`table/columns.tsx`) already had an `onError` handler that falls back to the original `header.jpg`; the v3.2.5 mobile card component didn't port it. `GameDetailDrawer` uses `g.header_image` directly, which is why the image always appeared once a card was tapped.
+- Fix: add the same `onError` fallback to the mobile card `<img>` — on a 404 it swaps `src` to `g.header_image`, with an `el.src !== g.header_image` guard against an infinite error loop.
+
 ## [v3.2.5] – 2026-05-20 (The "AC Nav + Mobile + Games Cleanup" Edition)
 
 Patch release on top of v3.2.4. One reported bug fix + three quality-of-life polish items. **Bug:** clicking any "Family" link in the Anti-Cheat Index sidebar redirected to the Dashboard instead of scrolling to the matching family table — `HashRouter` was treating the `<a href="#vac">` anchor as a route navigation. **Polish:** the `GamesTable` (1318 px wide) now degrades to a virtualised card list below the `md` breakpoint so mobile no longer needs horizontal scroll; the `AntiCheatList` sidebar drops to `md` instead of `lg` and exposes a horizontal chip nav on phones; `KpiCards` adds `md`/`lg` rungs to avoid uneven grid jumps. **Cleanup:** 93 per-genre markdown files in `games/` are removed (the web app's `/games?genre=X` filter has replaced them since v3.0); `generate_tables.py` now skips regeneration when game data hasn't actually changed via a `.gen-hash` checksum, cutting daily catalogue commits to roughly the days that move records. **New:** floating back-to-top button on the main scroll container, fades in past 400 px. Web app + desktop bumped `1.2.4` → `1.2.5`. Repo public-facing version `3.2.4` → `3.2.5`. Tag `v3.2.5` is GPG-signed; companion desktop tag is `desktop-v1.2.5`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.2.5-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.2.6-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.2.5"
+version = "1.2.6"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/components/games/table/MobileGameCards.tsx
+++ b/web/src/components/games/table/MobileGameCards.tsx
@@ -95,6 +95,13 @@ export function MobileGameCards({ records, selected, onSelect, onOpen }: Props) 
                     width={80}
                     height={37}
                     className="h-10 w-20 rounded object-cover"
+                    onError={(e) => {
+                      // capsule_184x69 variant 404s for some games — fall
+                      // back to the original header.jpg. Guard prevents an
+                      // infinite loop if both URLs fail.
+                      const el = e.currentTarget;
+                      if (el.src !== g.header_image) el.src = g.header_image;
+                    }}
                   />
                 ) : (
                   <div className="h-10 w-20 rounded bg-muted" />

--- a/web/src/pages/AntiCheatList.tsx
+++ b/web/src/pages/AntiCheatList.tsx
@@ -140,7 +140,7 @@ export function AntiCheatListPage() {
               <Badge variant="secondary">{b.games.length}</Badge>
             </CardHeader>
             <CardContent>
-              <div className="overflow-hidden rounded-md border">
+              <div className="overflow-x-auto rounded-md border">
                 <table className="w-full text-sm">
                   <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
                     <tr>


### PR DESCRIPTION
## Summary
Two mobile-viewport regressions from the v3.2.5 responsive overhaul.

- **AC Index table** (`AntiCheatList.tsx`): per-family table wrapper was `overflow-hidden`, clipping the right-hand columns on a 390 px viewport with no scroll. Changed to `overflow-x-auto`.
- **Mobile card thumbnail** (`MobileGameCards.tsx`): the `<img>` loads the `capsule_184x69.jpg` variant via `headerToCapsule()`; Steam's CDN lacks that variant for some games → blank thumbnail. Ported the `onError` → original `header.jpg` fallback already present on the desktop column.

## Test plan
- [x] `npm run build` (passes, 2418 modules)
- [x] `cargo check` (passes, v1.2.6 + Cargo.lock regen)
- [x] GPG signing verified on commit
- [x] DevTools mobile (390×844): `/charts/anti-cheat/list` tables scroll horizontally
- [x] DevTools mobile: `/games` card list shows all thumbnails (incl. small indie titles)
- [x] Tap a mobile card → `GameDetailDrawer` image still renders (no regression)

## Stats
8 files changed, +28 / -6. Version `1.2.5` → `1.2.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)