### PR TITLE
v3.3.0: Web perf overhaul (lazy-load) + error-page system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.3.0] – 2026-06-12 (The "Lazy-Load + Error Pages" Edition)
+
+Feature release on top of v3.2.7, two themes: a web-app performance overhaul (route-level code splitting, lazy echarts/openpgp/locale chunks — first-load JS drops from ~574 KB to ~163 KB gzipped, −72%) and a proper error-page system (403/404/419/5xx/offline pages, React error boundaries, a real GitHub Pages `404.html`). Web app + desktop bumped `1.2.7` → `1.3.0`. Repo public-facing version `3.2.7` → `3.3.0`. Tag `v3.3.0` is GPG-signed; companion desktop tag is `desktop-v1.3.0`.
+
+### ⚡ Lazy-loading overhaul
+
+- **Route splitting** — [web/src/App.tsx](web/src/App.tsx): every page except `Dashboard` (the landing route) is now `React.lazy` via a new `lazyWithRetry` helper ([web/src/lib/lazy.ts](web/src/lib/lazy.ts)). The `<Suspense>` boundary sits inside [Layout.tsx](web/src/components/layout/Layout.tsx) around `<Outlet/>`, so the sidebar/topbar stay mounted during navigation; fallback reuses the existing `LoadingState`.
+- **echarts (~666 KB raw)** — new [LazyEChart.tsx](web/src/components/charts/LazyEChart.tsx) wrapper is the single dynamic boundary for `EChart.tsx` (which keeps the `echarts.use([...])` registration). All 15 chart components swap one import line; a fixed-height `animate-pulse` skeleton prevents layout shift. echarts now downloads only when a chart mounts.
+- **openpgp (~391 KB raw)** — [web/src/lib/gpg.ts](web/src/lib/gpg.ts) switches to a type-only import + memoized `await import("openpgp")`. All exports were already async, so zero caller changes; visitors without a saved GPG key never download the crypto chunk at all.
+- **Per-locale i18n** — [web/src/i18n/index.ts](web/src/i18n/index.ts): `en.json` stays bundled (it's `fallbackLng` — a missing key can never render raw), `vi.json` becomes a dynamic import. `initI18n()` preloads the detected locale before `i18n.init`, and [main.tsx](web/src/main.tsx) awaits it before first render — no flash of raw keys, verified with a hard reload under `f2p:lang=vi`. `setLanguage()` is now async and loads the bundle *before* switching. Also syncs `<html lang>` (was hardcoded `vi` for everyone).
+- **manualChunks fix** — forcing `echarts`/`openpgp` into `manualChunks` made Rollup hoist shared helpers (tslib) *into* the echarts chunk, which the eager graph then statically imported — echarts was being modulepreloaded on first paint, nullifying the lazy boundary. Both entries are removed from [vite.config.ts](web/vite.config.ts); the dynamic-import boundaries split them naturally. `dist/index.html` now modulepreloads only `react` + `query`.
+- Net effect: eager JS `~1746 KB → ~494 KB` raw (`~574 → ~163 KB` gzip). The PWA still precaches everything in the background, but first paint no longer waits for charts + crypto.
+
+### 🚦 Error pages (403 / 404 / 419 / 500 / 502 / 503 / 504 / offline)
+
+- New [web/src/pages/errors/ErrorPage.tsx](web/src/pages/errors/ErrorPage.tsx) — one config-driven component: per-code lucide icon + tone (neutral/warn/destructive, reusing the exact `ErrorState`/`PwaIndicator` palettes), mono `ERROR {{code}}` badge, i18n'd title/description, and three actions (Go home / Reload / Report issue → GitHub Issues). Full `errors.*` key blocks added to both [en.json](web/src/i18n/locales/en.json) and [vi.json](web/src/i18n/locales/vi.json). Kept in the eager bundle on purpose — error UI must not live in a lazy chunk.
+- Routing — `#/error/:code` deep links via `ErrorCodeRoute` (unknown codes render 404 in place, no redirect), and the catch-all `<Route path="*">` now shows a real 404 page instead of silently redirecting to the Dashboard.
+- **GitHub Pages `404.html`** — new [web/public/404.html](web/public/404.html): standalone dark page (inline CSS, no JS deps), bilingual via a one-liner that respects the app's own `f2p:lang`, `noindex`, absolute link back to `/free-steam-games-list/#/`. Excluded from the SW precache via `globIgnores` in [vite.config.ts](web/vite.config.ts) — SW-controlled clients get `navigateFallback` and never see it.
+
+### 🛡️ Error boundaries + stale-deploy resilience
+
+- New [ErrorBoundary.tsx](web/src/components/common/ErrorBoundary.tsx) (own ~40-line class, no new dep) with a `resetKey` prop — navigating away clears a stuck error *without* remounting the page subtree on every navigation (which `key` would do, destroying table scroll/selection state).
+- Two mounts: route-level inside `Layout` (chunk-load error → 503 page with "new version deployed, reload" copy; render crash → 500 page, error message shown in dev only), and a top-level [AppErrorBoundary](web/src/components/common/AppErrorBoundary.tsx) outside the router with inline styles + hardcoded bilingual strings — immune to i18n/Tailwind/router failures.
+- `lazyWithRetry` handles the deploy-mid-session case: a chunk 404 triggers ONE auto-reload per tab (`sessionStorage` flag, try/catch-guarded for lockdown webviews) which also picks up the waiting service worker; a second failure throws to the boundary.
+
+### 🔌 Real error flows wired in
+
+- [QueryState.tsx](web/src/components/common/QueryState.tsx) `ErrorState` upgraded in place (contract preserved): offline detection swaps in the `errors.offline.*` copy + `WifiOff` icon, plus Retry / Report-issue action buttons. All 17 call sites now pass `onRetry={() => void q.refetch()}`.
+- Expired/revoked token on session restore ([stores/auth.ts](web/src/stores/auth.ts) `hydrate()` catch) now fires a Sonner toast with the shared `errors.419.*` copy and an "Open Settings" action (10 s duration — the 4 s default is too short for action toasts). Deliberately a toast, not a redirect: don't hijack whatever page the user opened. Auth gating on `/add` stays as-is.
+
+### 🖼️ Images
+
+- `decoding="async"` added to every `<img>` (10 sites: table thumbs, mobile cards, command palette, detail drawer, avatars, About QRs) — keeps image decode off the main thread during virtualised scrolling.
+- Detail drawer header image now goes through a new `preferWebp()` ([web/src/lib/image.ts](web/src/lib/image.ts)): weserv WebP transcode (~50 KB → ~20 KB) on web, **direct Steam URL on Tauri desktop** (no third-party calls from the bundled app), with an `onError` fallback to the original. Replaces the old `<picture><source>` markup, which only falls back on unsupported *type* — a weserv outage would have shown a broken image. Thumbnails intentionally stay on direct Steam capsules (~10 KB, SW-cached); `webpProxyUrl` is no longer exported.
+
+### ⌨️ Search responsiveness
+
+- [GamesTable.tsx](web/src/components/games/GamesTable.tsx): the Fuse.js search input is wrapped in `useDeferredValue` — typing stays per-keystroke responsive while filtering ~1.2k records lags at React's low priority. No debounce timer (deferral only delays when the machine is actually busy). Same treatment + `useMemo` for the command palette's game scan.
+
+### 🧰 Tooling & misc
+
+- `rollup-plugin-visualizer` devDependency + `npm run analyze` (`vite build --mode analyze` → `dist/stats.html` treemap, gzip/brotli sizes).
+- [index.html](web/index.html): `preconnect` hints for `raw.githubusercontent.com` (shard fetches, crossorigin) and `shared.akamai.steamstatic.com` (thumbnails).
+- `npm audit fix` — react-router open-redirect advisory GHSA-2j2x-hqr9-3h42 (`react-router-dom` 6.30.x patch line); `npm audit` and `pip-audit` both report 0 known vulnerabilities.
+
 ## [v3.2.7] – 2026-05-22 (The "Coming-Soon Guard + Dead-Code Cleanup" Edition)
 
 Maintenance release on top of v3.2.6. A small, useful batch: the Python pipeline now rejects unreleased ("coming soon") games at ingest instead of listing titles nobody can play yet; a one-time dead-code sweep across the web app and the pipeline; and three dev-tooling additions (knip, vulture, pip-audit) so future releases can run the same checks. Web app + desktop bumped `1.2.6` → `1.2.7`. Repo public-facing version `3.2.6` → `3.2.7`. Tag `v3.2.7` is GPG-signed; companion desktop tag is `desktop-v1.2.7`.

--- a/web/index.html
+++ b/web/index.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0f172a" />
 
+    <!-- Shave a DNS+TLS handshake off the first shard fetch / thumbnails.
+         raw.githubusercontent is fetched with CORS, hence crossorigin. -->
+    <link rel="preconnect" href="https://raw.githubusercontent.com" crossorigin />
+    <link rel="preconnect" href="https://shared.akamai.steamstatic.com" />
+
     <title>Steam F2P Tracker</title>
     <meta
       name="description"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,6 +46,7 @@
         "autoprefixer": "^10.4.20",
         "knip": "^6.14.2",
         "postcss": "^8.4.47",
+        "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^3.4.13",
         "typescript": "^5.6.2",
         "vite": "^7.1.6",
@@ -3585,9 +3586,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4608,6 +4609,32 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -4907,6 +4934,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5033,6 +5076,21 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/clsx": {
@@ -5226,6 +5284,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5242,6 +5330,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -5356,6 +5457,13 @@
       "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -5869,6 +5977,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6327,6 +6458,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6382,6 +6529,38 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -6619,6 +6798,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -7086,6 +7281,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openpgp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.0.tgz",
@@ -7435,6 +7651,19 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -7587,12 +7816,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7602,13 +7831,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7857,6 +8086,73 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.3",
         "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -8224,6 +8520,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -8324,6 +8638,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-comments": {
@@ -9402,6 +9732,51 @@
         "workbox-core": "7.4.1"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9423,6 +9798,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/zod": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,12 +1,13 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:desktop": "tsc -b && vite build --base /",
+    "analyze": "vite build --mode analyze",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit",
     "knip": "knip",
@@ -53,6 +54,7 @@
     "autoprefixer": "^10.4.20",
     "knip": "^6.14.2",
     "postcss": "^8.4.47",
+    "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "vite": "^7.1.6",

--- a/web/public/404.html
+++ b/web/public/404.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="theme-color" content="#0f172a">
+  <title>404 — Steam F2P Tracker</title>
+  <!--
+    Served by GitHub Pages for paths outside the SPA (the app itself routes
+    behind #/, so in-app 404s are handled by the router's NotFound page).
+    Standalone on purpose: no JS deps, inline CSS, bilingual via one-liner.
+    Excluded from the service worker precache (workbox globIgnores).
+  -->
+  <style>
+    body{margin:0;min-height:100vh;display:grid;place-items:center;background:#0f172a;color:#e2e8f0;font-family:Inter,system-ui,sans-serif}
+    .card{text-align:center;max-width:420px;padding:32px;border:1px solid #1e293b;border-radius:12px;background:#111c33}
+    .code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;letter-spacing:.3em;color:#64748b}
+    h1{font-size:20px;margin:.5em 0}
+    p{font-size:14px;color:#94a3b8;line-height:1.5}
+    code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#cbd5e1}
+    a.btn{display:inline-block;margin-top:20px;padding:8px 20px;border-radius:8px;background:#2563eb;color:#fff;text-decoration:none;font-size:14px}
+    [data-l]{display:none}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="code">ERROR 404</div>
+    <h1 data-l="en">Page not found</h1>
+    <h1 data-l="vi">Không tìm thấy trang</h1>
+    <p data-l="en">This page doesn't exist. The app lives behind the <code>#/</code> router.</p>
+    <p data-l="vi">Trang này không tồn tại. Ứng dụng chạy sau bộ định tuyến <code>#/</code>.</p>
+    <a class="btn" href="/free-steam-games-list/#/" data-l="en">Go to app</a>
+    <a class="btn" href="/free-steam-games-list/#/" data-l="vi">Về trang chính</a>
+  </div>
+  <script>
+    // Same-origin: respect the app's own language choice, then the browser's.
+    var l="en";
+    try{l=((localStorage.getItem("f2p:lang")||navigator.language||"en").slice(0,2)==="vi")?"vi":"en"}catch(e){}
+    document.documentElement.lang=l;
+    document.querySelectorAll('[data-l="'+l+'"]').forEach(function(e){e.style.display="block"});
+  </script>
+</body>
+</html>

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.2.7"
+version = "1.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.2.7"
+version = "1.3.0"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,26 +1,77 @@
 import { Routes, Route, Navigate } from "react-router-dom";
 import { Layout } from "./components/layout/Layout";
 import { Dashboard } from "./pages/Dashboard";
-import { GamesPage } from "./pages/Games";
-import { TopOnlinePage } from "./pages/TopOnline";
-import { TopOfflinePage } from "./pages/TopOffline";
-import { GenresPage } from "./pages/charts/Genres";
-import { PlatformsPage } from "./pages/charts/Platforms";
-import { TagsPage } from "./pages/charts/Tags";
-import { AntiCheatPage } from "./pages/charts/AntiCheat";
-import { AntiCheatListPage } from "./pages/AntiCheatList";
-import { ReviewsPage } from "./pages/charts/Reviews";
-import { LanguagesPage } from "./pages/charts/Languages";
-import { TimePage } from "./pages/charts/Time";
-import { PlayersPage } from "./pages/charts/Players";
-import { DrmPage } from "./pages/charts/Drm";
-import { DelistedPage } from "./pages/charts/Delisted";
-import { HealthPage } from "./pages/Health";
-import { ActivityPage } from "./pages/Activity";
-import { AddPage } from "./pages/Add";
-import { AboutPage } from "./pages/About";
-import { DonatePage } from "./pages/Donate";
-import { SettingsPage } from "./pages/Settings";
+import { lazyWithRetry } from "./lib/lazy";
+
+// Dashboard (the landing page) and Layout stay eager — splitting them would
+// just add a request waterfall to the first paint. Everything else loads on
+// navigation; Layout's <Suspense> keeps the shell mounted meanwhile.
+const GamesPage = lazyWithRetry(() =>
+  import("./pages/Games").then((m) => ({ default: m.GamesPage })),
+);
+const TopOnlinePage = lazyWithRetry(() =>
+  import("./pages/TopOnline").then((m) => ({ default: m.TopOnlinePage })),
+);
+const TopOfflinePage = lazyWithRetry(() =>
+  import("./pages/TopOffline").then((m) => ({ default: m.TopOfflinePage })),
+);
+const GenresPage = lazyWithRetry(() =>
+  import("./pages/charts/Genres").then((m) => ({ default: m.GenresPage })),
+);
+const PlatformsPage = lazyWithRetry(() =>
+  import("./pages/charts/Platforms").then((m) => ({ default: m.PlatformsPage })),
+);
+const TagsPage = lazyWithRetry(() =>
+  import("./pages/charts/Tags").then((m) => ({ default: m.TagsPage })),
+);
+const AntiCheatPage = lazyWithRetry(() =>
+  import("./pages/charts/AntiCheat").then((m) => ({ default: m.AntiCheatPage })),
+);
+const AntiCheatListPage = lazyWithRetry(() =>
+  import("./pages/AntiCheatList").then((m) => ({ default: m.AntiCheatListPage })),
+);
+const ReviewsPage = lazyWithRetry(() =>
+  import("./pages/charts/Reviews").then((m) => ({ default: m.ReviewsPage })),
+);
+const LanguagesPage = lazyWithRetry(() =>
+  import("./pages/charts/Languages").then((m) => ({ default: m.LanguagesPage })),
+);
+const TimePage = lazyWithRetry(() =>
+  import("./pages/charts/Time").then((m) => ({ default: m.TimePage })),
+);
+const PlayersPage = lazyWithRetry(() =>
+  import("./pages/charts/Players").then((m) => ({ default: m.PlayersPage })),
+);
+const DrmPage = lazyWithRetry(() =>
+  import("./pages/charts/Drm").then((m) => ({ default: m.DrmPage })),
+);
+const DelistedPage = lazyWithRetry(() =>
+  import("./pages/charts/Delisted").then((m) => ({ default: m.DelistedPage })),
+);
+const HealthPage = lazyWithRetry(() =>
+  import("./pages/Health").then((m) => ({ default: m.HealthPage })),
+);
+const ActivityPage = lazyWithRetry(() =>
+  import("./pages/Activity").then((m) => ({ default: m.ActivityPage })),
+);
+const AddPage = lazyWithRetry(() =>
+  import("./pages/Add").then((m) => ({ default: m.AddPage })),
+);
+const AboutPage = lazyWithRetry(() =>
+  import("./pages/About").then((m) => ({ default: m.AboutPage })),
+);
+const DonatePage = lazyWithRetry(() =>
+  import("./pages/Donate").then((m) => ({ default: m.DonatePage })),
+);
+const SettingsPage = lazyWithRetry(() =>
+  import("./pages/Settings").then((m) => ({ default: m.SettingsPage })),
+);
+const ErrorCodePage = lazyWithRetry(() =>
+  import("./pages/errors/ErrorCodeRoute").then((m) => ({ default: m.ErrorCodeRoute })),
+);
+const NotFoundPage = lazyWithRetry(() =>
+  import("./pages/errors/NotFound").then((m) => ({ default: m.NotFoundPage })),
+);
 
 export default function App() {
   return (
@@ -51,7 +102,8 @@ export default function App() {
         <Route path="about" element={<AboutPage />} />
         <Route path="donate" element={<DonatePage />} />
         <Route path="settings" element={<SettingsPage />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route path="error/:code" element={<ErrorCodePage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/auth/AuthPanel.tsx
+++ b/web/src/components/auth/AuthPanel.tsx
@@ -30,6 +30,7 @@ export function AuthPanel() {
             <img
               src={auth.user.avatar_url}
               alt=""
+              decoding="async"
               className="h-12 w-12 rounded-full border"
             />
             <div className="min-w-0 flex-1">

--- a/web/src/components/charts/AddedCumulativeLine.tsx
+++ b/web/src/components/charts/AddedCumulativeLine.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/AddedPerMonthBar.tsx
+++ b/web/src/components/charts/AddedPerMonthBar.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/AntiCheatStacked.tsx
+++ b/web/src/components/charts/AntiCheatStacked.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/DelistedReasonBreakdown.tsx
+++ b/web/src/components/charts/DelistedReasonBreakdown.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { RemovedGame } from "../../hooks/useRemovedGames";
 
 interface Props {

--- a/web/src/components/charts/DelistedTimeline.tsx
+++ b/web/src/components/charts/DelistedTimeline.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { RemovedGame } from "../../hooks/useRemovedGames";
 
 interface Props {

--- a/web/src/components/charts/DrmDlcBars.tsx
+++ b/web/src/components/charts/DrmDlcBars.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/GenreTreemap.tsx
+++ b/web/src/components/charts/GenreTreemap.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/LanguagesHeatmap.tsx
+++ b/web/src/components/charts/LanguagesHeatmap.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/LazyEChart.tsx
+++ b/web/src/components/charts/LazyEChart.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from "react";
+import type { EChartsCoreOption } from "echarts/core";
+import { lazyWithRetry } from "../../lib/lazy";
+
+// EChart.tsx statically imports echarts/core + echarts-wordcloud (~666 KB).
+// This wrapper is the single lazy boundary for all of it: chart components
+// import { LazyEChart as EChart } so the echarts chunk only downloads when a
+// chart actually mounts — off the critical path of the Dashboard first paint.
+// The EChartsCoreOption import above is type-only, so it doesn't re-eagerify
+// the chunk.
+const Inner = lazyWithRetry(() =>
+  import("./EChart").then((m) => ({ default: m.EChart })),
+);
+
+interface Props {
+  option: EChartsCoreOption;
+  height?: number | string;
+  className?: string;
+}
+
+export function LazyEChart({ height = 360, ...rest }: Props) {
+  return (
+    <Suspense
+      fallback={
+        // Fixed-height skeleton — prevents layout shift while echarts loads.
+        <div style={{ height }} className="animate-pulse rounded-md bg-muted/40" />
+      }
+    >
+      <Inner height={height} {...rest} />
+    </Suspense>
+  );
+}

--- a/web/src/components/charts/PlatformsDonut.tsx
+++ b/web/src/components/charts/PlatformsDonut.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/PlayerTiersPie.tsx
+++ b/web/src/components/charts/PlayerTiersPie.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import { parseIntSafe } from "../../lib/utils";
 import type { GameRecord } from "../../lib/schema";
 

--- a/web/src/components/charts/ReleaseYearHistogram.tsx
+++ b/web/src/components/charts/ReleaseYearHistogram.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 
 interface Props {

--- a/web/src/components/charts/ReviewsHistogram.tsx
+++ b/web/src/components/charts/ReviewsHistogram.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import { parseReviewPercent } from "../../lib/utils";
 import type { GameRecord } from "../../lib/schema";
 

--- a/web/src/components/charts/TagsWordCloud.tsx
+++ b/web/src/components/charts/TagsWordCloud.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import type { GameRecord } from "../../lib/schema";
 import { SKIP_GENRE_TAGS } from "../../lib/schema";
 

--- a/web/src/components/charts/TopOfflineBar.tsx
+++ b/web/src/components/charts/TopOfflineBar.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import { parseIntSafe } from "../../lib/utils";
 import type { GameRecord } from "../../lib/schema";
 

--- a/web/src/components/charts/TopOnlineBar.tsx
+++ b/web/src/components/charts/TopOnlineBar.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EChart } from "./EChart";
+import { LazyEChart as EChart } from "./LazyEChart";
 import { parseIntSafe } from "../../lib/utils";
 import type { GameRecord } from "../../lib/schema";
 

--- a/web/src/components/common/AppErrorBoundary.tsx
+++ b/web/src/components/common/AppErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+/**
+ * Last-resort boundary mounted OUTSIDE the router/providers in main.tsx.
+ * Its fallback must not depend on i18n, Tailwind, or react-router — any of
+ * them could be the thing that crashed — so it uses inline styles and
+ * hardcoded bilingual strings. Background matches the PWA theme_color.
+ */
+export function AppErrorBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary
+      fallback={(error) => (
+        <div
+          style={{
+            minHeight: "100vh",
+            display: "grid",
+            placeItems: "center",
+            background: "#0f172a",
+            color: "#e2e8f0",
+            fontFamily: "Inter, system-ui, sans-serif",
+          }}
+        >
+          <div style={{ textAlign: "center", maxWidth: 420, padding: 24 }}>
+            <h1 style={{ fontSize: 18, marginBottom: 8 }}>
+              Something went wrong / Đã xảy ra lỗi
+            </h1>
+            <p style={{ fontSize: 13, opacity: 0.7, wordBreak: "break-word" }}>
+              {error.message}
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              style={{
+                marginTop: 16,
+                padding: "8px 16px",
+                borderRadius: 6,
+                border: "1px solid #334155",
+                background: "#1e293b",
+                color: "inherit",
+                cursor: "pointer",
+              }}
+            >
+              Reload / Tải lại
+            </button>
+          </div>
+        </div>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/web/src/components/common/CommandPalette.tsx
+++ b/web/src/components/common/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { Command } from "cmdk";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -85,9 +85,12 @@ export function CommandPalette() {
     setSearch("");
   }
 
-  const gameMatches = (() => {
-    if (!games.data || search.trim().length < 2) return [];
-    const q = search.toLowerCase();
+  // Memo + deferral: the scan re-ran on every render before; now it only
+  // recomputes when the (low-priority) search value or dataset changes.
+  const deferredSearch = useDeferredValue(search);
+  const gameMatches = useMemo(() => {
+    if (!games.data || deferredSearch.trim().length < 2) return [];
+    const q = deferredSearch.toLowerCase();
     const out = [];
     for (const r of games.data.records) {
       if (r.name && r.name.toLowerCase().includes(q)) {
@@ -96,7 +99,7 @@ export function CommandPalette() {
       }
     }
     return out;
-  })();
+  }, [games.data, deferredSearch]);
 
   if (!open) return null;
 
@@ -190,6 +193,7 @@ export function CommandPalette() {
                     {r.header_image ? (
                       <img
                         loading="lazy"
+                        decoding="async"
                         src={headerToCapsule(r.header_image)}
                         alt=""
                         width={92}

--- a/web/src/components/common/ErrorBoundary.tsx
+++ b/web/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback: (error: Error, reset: () => void) => ReactNode;
+  /**
+   * When this value changes, an active error state is cleared. Used with the
+   * route pathname so navigating away from a crashed page recovers — without
+   * remounting the whole subtree on every navigation (which `key` would do,
+   * destroying table scroll/selection state).
+   */
+  resetKey?: unknown;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  componentDidUpdate(prev: Props): void {
+    if (this.state.error && prev.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  render(): ReactNode {
+    return this.state.error
+      ? this.props.fallback(this.state.error, () => this.setState({ error: null }))
+      : this.props.children;
+  }
+}

--- a/web/src/components/common/QueryState.tsx
+++ b/web/src/components/common/QueryState.tsx
@@ -1,5 +1,7 @@
-import { Loader2, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle, WifiOff, RotateCw, Bug } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Button } from "../ui/button";
+import { REPORT_ISSUE_URL } from "../../pages/errors/ErrorPage";
 
 export function LoadingState({ label }: { label?: string }) {
   const { t } = useTranslation();
@@ -13,14 +15,56 @@ export function LoadingState({ label }: { label?: string }) {
   );
 }
 
-export function ErrorState({ error }: { error: Error }) {
+export function ErrorState({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry?: () => void;
+}) {
   const { t } = useTranslation();
+  // Shard fetch failed while the browser knows it's offline → say that
+  // instead of a generic failure; cached data may still serve elsewhere.
+  const offline = !navigator.onLine;
+  const Icon = offline ? WifiOff : AlertTriangle;
   return (
     <div className="flex h-[60vh] items-center justify-center">
-      <div className="max-w-md rounded-lg border border-destructive/40 bg-destructive/5 p-6 text-center">
-        <AlertTriangle className="mx-auto mb-3 h-8 w-8 text-destructive" />
-        <h2 className="mb-1 text-lg font-semibold">{t("system.failedToLoadData")}</h2>
-        <p className="text-sm text-muted-foreground">{error.message}</p>
+      <div
+        className={
+          offline
+            ? "max-w-md rounded-lg border border-amber-500/30 bg-amber-500/10 p-6 text-center"
+            : "max-w-md rounded-lg border border-destructive/40 bg-destructive/5 p-6 text-center"
+        }
+      >
+        <Icon
+          className={
+            offline
+              ? "mx-auto mb-3 h-8 w-8 text-amber-400"
+              : "mx-auto mb-3 h-8 w-8 text-destructive"
+          }
+        />
+        <h2 className="mb-1 text-lg font-semibold">
+          {offline ? t("errors.offline.title") : t("system.failedToLoadData")}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {offline ? t("errors.offline.description") : error.message}
+        </p>
+        <div className="mt-4 flex flex-wrap justify-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onRetry ?? (() => window.location.reload())}
+          >
+            <RotateCw className="mr-1 h-3.5 w-3.5" />
+            {t("errors.actions.retry")}
+          </Button>
+          <Button asChild size="sm" variant="ghost">
+            <a href={REPORT_ISSUE_URL} target="_blank" rel="noreferrer">
+              <Bug className="mr-1 h-3.5 w-3.5" />
+              {t("errors.actions.report")}
+            </a>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/games/GameDetailDrawer.tsx
+++ b/web/src/components/games/GameDetailDrawer.tsx
@@ -29,7 +29,7 @@ import {
 } from "../../lib/utils";
 import { extractAppid } from "../../lib/data-store";
 import { steamProtocolUrl, steamWebUrl } from "../../lib/steam-link";
-import { webpProxyUrl } from "../../lib/image";
+import { preferWebp } from "../../lib/image";
 import type { GameRecord } from "../../lib/schema";
 import { EditGameDrawer } from "./EditGameDrawer";
 import { useIsOwner } from "../../hooks/useIsOwner";
@@ -95,20 +95,23 @@ export function GameDetailDrawer({ game, onClose, missing }: Props) {
           <div className="space-y-6">
             <DialogHeader>
               {game.header_image && (
-                <picture>
-                  <source
-                    srcSet={webpProxyUrl(game.header_image, 460)}
-                    type="image/webp"
-                  />
-                  <img
-                    loading="lazy"
-                    src={game.header_image}
-                    alt=""
-                    width={460}
-                    height={215}
-                    className="h-44 w-full rounded-md object-cover"
-                  />
-                </picture>
+                // Plain <img> instead of <picture>: a <source> only falls
+                // back on unsupported type, NOT on a failed load — a weserv
+                // outage would show a broken image. preferWebp also skips
+                // the proxy entirely on Tauri desktop.
+                <img
+                  loading="lazy"
+                  decoding="async"
+                  src={preferWebp(game.header_image, 460)}
+                  alt=""
+                  width={460}
+                  height={215}
+                  className="h-44 w-full rounded-md object-cover"
+                  onError={(e) => {
+                    const el = e.currentTarget;
+                    if (el.src !== game.header_image) el.src = game.header_image;
+                  }}
+                />
               )}
               <div className="flex items-start justify-between gap-3">
                 <DialogTitle className="text-xl">{game.name || "—"}</DialogTitle>

--- a/web/src/components/games/GamesTable.tsx
+++ b/web/src/components/games/GamesTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useEffect } from "react";
+import { useDeferredValue, useMemo, useRef, useState, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import Fuse from "fuse.js";
 import { useFilters } from "../../stores/filters";
@@ -19,7 +19,11 @@ interface Props {
 }
 
 export function GamesTable({ records, onRowOpen }: Props) {
-  const search = useFilters((s) => s.search);
+  // Deferred: the Topbar input stays per-keystroke responsive while the
+  // Fuse search over ~1.2k records lags behind at React's low priority.
+  // No debounce timer — deferral only delays when the machine is busy.
+  const searchRaw = useFilters((s) => s.search);
+  const search = useDeferredValue(searchRaw);
   const genre = useFilters((s) => s.genre);
   const typeGame = useFilters((s) => s.type_game);
   const platform = useFilters((s) => s.platform);

--- a/web/src/components/games/table/MobileGameCards.tsx
+++ b/web/src/components/games/table/MobileGameCards.tsx
@@ -90,6 +90,7 @@ export function MobileGameCards({ records, selected, onSelect, onOpen }: Props) 
                 {g.header_image ? (
                   <img
                     loading="lazy"
+                    decoding="async"
                     src={headerToCapsule(g.header_image)}
                     alt=""
                     width={80}

--- a/web/src/components/games/table/columns.tsx
+++ b/web/src/components/games/table/columns.tsx
@@ -31,6 +31,7 @@ export const COLS: ColDef[] = [
       g.header_image ? (
         <img
           loading="lazy"
+          decoding="async"
           src={headerToCapsule(g.header_image)}
           alt=""
           width={92}

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,13 +1,20 @@
-import { Outlet } from "react-router-dom";
-import { useRef, useState } from "react";
+import { Outlet, useLocation } from "react-router-dom";
+import { Suspense, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Sidebar, MobileSidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 import { CommandPalette } from "../common/CommandPalette";
 import { BackToTop } from "../common/BackToTop";
+import { ErrorBoundary } from "../common/ErrorBoundary";
+import { LoadingState } from "../common/QueryState";
+import { ErrorPage } from "../../pages/errors/ErrorPage";
+import { isChunkLoadError } from "../../lib/lazy";
 import { useGpgAutolock } from "../../hooks/useGpgAutolock";
 
 export function Layout() {
   useGpgAutolock();
+  const { t } = useTranslation();
+  const location = useLocation();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const mainRef = useRef<HTMLElement>(null);
   return (
@@ -17,7 +24,30 @@ export function Layout() {
         <Topbar onMenuToggle={() => setMobileNavOpen(true)} />
         <main ref={mainRef} className="flex-1 overflow-y-auto">
           <div className="container max-w-screen-2xl py-6">
-            <Outlet />
+            {/*
+              Boundary + Suspense live INSIDE the layout so the sidebar/topbar
+              stay mounted during lazy-route loads and page crashes. resetKey
+              clears a stuck error when the user navigates away. A chunk-load
+              error landing here means lazyWithRetry already burned its one
+              auto-reload — show the "new deploy, reload" copy.
+            */}
+            <ErrorBoundary
+              resetKey={location.pathname}
+              fallback={(err) =>
+                isChunkLoadError(err) ? (
+                  <ErrorPage code="503" detail={t("errors.boundary.chunkDescription")} />
+                ) : (
+                  <ErrorPage
+                    code="500"
+                    detail={import.meta.env.DEV ? err.message : undefined}
+                  />
+                )
+              }
+            >
+              <Suspense fallback={<LoadingState />}>
+                <Outlet />
+              </Suspense>
+            </ErrorBoundary>
           </div>
         </main>
       </div>

--- a/web/src/components/layout/Topbar.tsx
+++ b/web/src/components/layout/Topbar.tsx
@@ -129,6 +129,7 @@ export function Topbar({ onMenuToggle }: TopbarProps = {}) {
             <img
               src={auth.user.avatar_url}
               alt=""
+              decoding="async"
               className="h-5 w-5 rounded-full"
             />
             <span className="font-medium">@{auth.user.login}</span>

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -2,46 +2,102 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import en from "./locales/en.json";
-import vi from "./locales/vi.json";
 
 /**
- * Single resource bundle ships with the app — no async loading. Two
- * languages right now (en, vi); easy to add more by copying en.json and
- * registering it below.
+ * Per-locale lazy loading. `en` stays statically bundled — it is the
+ * fallbackLng, so a missing key can never render raw (a lazy fallback that
+ * failed to fetch would). Every other locale is a dynamic import that only
+ * the users of that language download (~6 KB gz each off everyone else's
+ * critical path).
  *
  * `f2p:lang` in localStorage is the canonical override. If absent we fall
  * back to the browser language detector (navigator.language → ...).
+ *
+ * main.tsx awaits initI18n() before rendering, so render-time t() always
+ * happens post-init — no flash of raw keys.
  */
 export const SUPPORTED_LANGUAGES = ["en", "vi"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
-void i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    resources: {
-      en: { translation: en },
-      vi: { translation: vi },
-    },
-    fallbackLng: "en",
-    supportedLngs: SUPPORTED_LANGUAGES as unknown as string[],
-    interpolation: { escapeValue: false },
-    detection: {
-      order: ["localStorage", "navigator"],
-      lookupLocalStorage: "f2p:lang",
-      caches: ["localStorage"],
-    },
+const loaders: Record<SupportedLanguage, () => Promise<{ default: object }>> = {
+  en: () => Promise.resolve({ default: en }),
+  vi: () => import("./locales/vi.json"),
+};
+
+function isSupported(lang: string): lang is SupportedLanguage {
+  return (SUPPORTED_LANGUAGES as readonly string[]).includes(lang);
+}
+
+/**
+ * Mirror of the LanguageDetector order (localStorage "f2p:lang" → navigator
+ * → en) so we can preload the right bundle BEFORE init. If the two ever
+ * diverged, worst case is an en-fallback render until setLanguage runs —
+ * never raw keys.
+ */
+function detectInitialLanguage(): SupportedLanguage {
+  try {
+    const stored = localStorage.getItem("f2p:lang");
+    if (stored && isSupported(stored)) return stored;
+  } catch {
+    /* storage blocked → fall through to navigator */
+  }
+  for (const nav of navigator.languages ?? [navigator.language]) {
+    const base = nav?.slice(0, 2).toLowerCase();
+    if (base && isSupported(base)) return base;
+  }
+  return "en";
+}
+
+async function ensureBundle(lang: SupportedLanguage): Promise<void> {
+  if (i18n.hasResourceBundle(lang, "translation")) return;
+  const data = await loaders[lang]();
+  i18n.addResourceBundle(lang, "translation", data.default, true, true);
+}
+
+export async function initI18n(): Promise<void> {
+  const initial = detectInitialLanguage();
+  const resources: Record<string, { translation: object }> = {
+    en: { translation: en },
+  };
+  if (initial !== "en") {
+    try {
+      const data = await loaders[initial]();
+      resources[initial] = { translation: data.default };
+    } catch {
+      // Network failure on first load → render with en fallback; the bundle
+      // is retried on the next language switch via ensureBundle.
+    }
+  }
+  await i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      resources,
+      fallbackLng: "en",
+      supportedLngs: SUPPORTED_LANGUAGES as unknown as string[],
+      interpolation: { escapeValue: false },
+      detection: {
+        order: ["localStorage", "navigator"],
+        lookupLocalStorage: "f2p:lang",
+        caches: ["localStorage"],
+      },
+    });
+  // index.html hardcodes lang="vi" — keep <html lang> in sync for a11y/SEO.
+  document.documentElement.lang = i18n.resolvedLanguage ?? initial;
+  i18n.on("languageChanged", (lang) => {
+    document.documentElement.lang = lang;
   });
+}
 
 export default i18n;
 
-export function setLanguage(lang: SupportedLanguage): void {
-  void i18n.changeLanguage(lang);
+/** Loads the locale bundle BEFORE switching — no flash of raw keys. */
+export async function setLanguage(lang: SupportedLanguage): Promise<void> {
+  await ensureBundle(lang);
+  await i18n.changeLanguage(lang);
 }
 
 export function currentLanguage(): SupportedLanguage {
   const cur = i18n.resolvedLanguage ?? i18n.language ?? "en";
-  return (SUPPORTED_LANGUAGES as readonly string[]).includes(cur)
-    ? (cur as SupportedLanguage)
-    : "en";
+  return isSupported(cur) ? cur : "en";
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -446,5 +446,52 @@
     "playersPeak": "(peak {{peak}})",
     "viewSteamPage": "the Steam page",
     "viewHealth": "Health"
+  },
+  "errors": {
+    "code": "ERROR {{code}}",
+    "actions": {
+      "home": "Go home",
+      "reload": "Reload",
+      "retry": "Try again",
+      "report": "Report issue",
+      "openSettings": "Open Settings"
+    },
+    "403": {
+      "title": "Access denied",
+      "description": "You don't have permission to do that. Only the repository owner can edit data — check your token in Settings."
+    },
+    "404": {
+      "title": "Page not found",
+      "description": "The page you're looking for doesn't exist or was moved."
+    },
+    "419": {
+      "title": "Session expired",
+      "description": "Your authentication token is no longer valid. Sign in again from Settings."
+    },
+    "500": {
+      "title": "Something went wrong",
+      "description": "An unexpected error occurred while rendering this page."
+    },
+    "502": {
+      "title": "Bad gateway",
+      "description": "An upstream service returned an invalid response. Try again shortly."
+    },
+    "503": {
+      "title": "Service unavailable",
+      "description": "The data source is temporarily unreachable. Cached data may still be available."
+    },
+    "504": {
+      "title": "Request timed out",
+      "description": "The server took too long to respond. Check your connection and try again."
+    },
+    "offline": {
+      "badge": "OFFLINE",
+      "title": "You're offline",
+      "description": "No network connection. Previously loaded data is still available."
+    },
+    "boundary": {
+      "chunkTitle": "Update available",
+      "chunkDescription": "A new version was deployed while you were browsing. Reload to get the latest files."
+    }
   }
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -446,5 +446,52 @@
     "playersPeak": "(peak {{peak}})",
     "viewSteamPage": "trang Steam",
     "viewHealth": "Health"
+  },
+  "errors": {
+    "code": "LỖI {{code}}",
+    "actions": {
+      "home": "Về trang chính",
+      "reload": "Tải lại",
+      "retry": "Thử lại",
+      "report": "Báo lỗi",
+      "openSettings": "Mở Cài đặt"
+    },
+    "403": {
+      "title": "Truy cập bị từ chối",
+      "description": "Bạn không có quyền thực hiện thao tác này. Chỉ chủ repo mới được sửa dữ liệu — kiểm tra token trong Cài đặt."
+    },
+    "404": {
+      "title": "Không tìm thấy trang",
+      "description": "Trang bạn tìm không tồn tại hoặc đã bị di chuyển."
+    },
+    "419": {
+      "title": "Phiên đăng nhập hết hạn",
+      "description": "Token xác thực không còn hiệu lực. Hãy đăng nhập lại trong Cài đặt."
+    },
+    "500": {
+      "title": "Đã xảy ra lỗi",
+      "description": "Có lỗi không mong muốn khi hiển thị trang này."
+    },
+    "502": {
+      "title": "Gateway lỗi",
+      "description": "Dịch vụ trung gian trả về phản hồi không hợp lệ. Thử lại sau ít phút."
+    },
+    "503": {
+      "title": "Dịch vụ không khả dụng",
+      "description": "Nguồn dữ liệu tạm thời không truy cập được. Dữ liệu đã cache có thể vẫn xem được."
+    },
+    "504": {
+      "title": "Hết thời gian chờ",
+      "description": "Server phản hồi quá lâu. Kiểm tra kết nối mạng rồi thử lại."
+    },
+    "offline": {
+      "badge": "OFFLINE",
+      "title": "Bạn đang offline",
+      "description": "Không có kết nối mạng. Dữ liệu đã tải trước đó vẫn xem được."
+    },
+    "boundary": {
+      "chunkTitle": "Có bản cập nhật mới",
+      "chunkDescription": "Phiên bản mới vừa được deploy trong lúc bạn đang duyệt. Tải lại để lấy file mới nhất."
+    }
   }
 }

--- a/web/src/lib/external-open.ts
+++ b/web/src/lib/external-open.ts
@@ -7,7 +7,7 @@ interface TauriRuntime extends Window {
   __TAURI_INTERNALS__?: unknown;
 }
 
-function isTauri(): boolean {
+export function isTauri(): boolean {
   return (
     typeof window !== "undefined" &&
     !!(window as TauriRuntime).__TAURI_INTERNALS__

--- a/web/src/lib/gpg.ts
+++ b/web/src/lib/gpg.ts
@@ -11,7 +11,16 @@
  * weren't shipped alongside it, so we use the npm package instead — it
  * bundles all chunks and is tree-shakable to a similar size.
  */
-import * as openpgp from "openpgp";
+import type * as OpenPGP from "openpgp";
+
+// openpgp is ~370 KB — the single largest chunk. Type-only import above is
+// erased at build time; the value import below is dynamic and memoized, so
+// visitors without a saved key never download it at all. All exports were
+// already async, so no caller changes.
+let mod: typeof OpenPGP | null = null;
+async function pgp(): Promise<typeof OpenPGP> {
+  return (mod ??= await import("openpgp"));
+}
 
 export interface ParsedKey {
   armored: string;
@@ -30,7 +39,7 @@ function parseUserId(uid: string): { name: string; email: string } {
   return { name: m[1].trim(), email: m[2].trim() };
 }
 
-function summariseKey(key: openpgp.PrivateKey, armored: string): ParsedKey {
+function summariseKey(key: OpenPGP.PrivateKey, armored: string): ParsedKey {
   const userIds = key.getUserIDs();
   const primary = parseUserId(userIds[0] ?? "");
   const algInfo = key.getAlgorithmInfo();
@@ -53,6 +62,7 @@ function summariseKey(key: openpgp.PrivateKey, armored: string): ParsedKey {
 
 /** Parse an armored private key (does not decrypt). */
 export async function parsePrivateKey(armored: string): Promise<ParsedKey> {
+  const openpgp = await pgp();
   const key = await openpgp.readPrivateKey({ armoredKey: armored });
   return summariseKey(key, armored);
 }
@@ -60,7 +70,7 @@ export async function parsePrivateKey(armored: string): Promise<ParsedKey> {
 export interface UnlockedKey {
   parsed: ParsedKey;
   /** OpenPGP.js decrypted key — kept in memory only. */
-  key: openpgp.PrivateKey;
+  key: OpenPGP.PrivateKey;
 }
 
 /** Decrypt with passphrase. Throws if wrong passphrase. */
@@ -68,6 +78,7 @@ export async function unlockPrivateKey(
   armored: string,
   passphrase: string,
 ): Promise<UnlockedKey> {
+  const openpgp = await pgp();
   const privateKey = await openpgp.readPrivateKey({ armoredKey: armored });
   const decrypted = await openpgp.decryptKey({ privateKey, passphrase });
   return { parsed: summariseKey(decrypted, armored), key: decrypted };
@@ -93,6 +104,7 @@ export async function signCommitContent(
   unlocked: UnlockedKey,
   commitContent: string,
 ): Promise<string> {
+  const openpgp = await pgp();
   const bytes = new TextEncoder().encode(commitContent);
   const message = await openpgp.createMessage({ binary: bytes });
   // The OpenPGP.js v6.1.1 d.ts is missing this option, but it exists at
@@ -100,7 +112,7 @@ export async function signCommitContent(
   // unknown to satisfy TS without disabling strict mode.
   const signConfig = {
     nonDeterministicSignaturesViaNotation: false,
-  } as unknown as openpgp.PartialConfig;
+  } as unknown as OpenPGP.PartialConfig;
   const armored = await openpgp.sign({
     message,
     signingKeys: unlocked.key,

--- a/web/src/lib/image.ts
+++ b/web/src/lib/image.ts
@@ -6,16 +6,34 @@
  * thumbnails. For larger views we route through images.weserv.nl, which
  * transcodes to WebP on the fly.
  */
+import { isTauri } from "./external-open";
 
 export function headerToCapsule(url: string): string {
   if (!url || !url.includes("header.jpg")) return url;
   return url.replace("header.jpg", "capsule_184x69.jpg");
 }
 
-export function webpProxyUrl(url: string, width?: number): string {
+function webpProxyUrl(url: string, width?: number): string {
   if (!url) return url;
   const stripped = url.replace(/^https?:\/\//, "");
   const params = new URLSearchParams({ url: stripped, output: "webp", q: "75" });
   if (width) params.set("w", String(width));
   return `https://images.weserv.nl/?${params.toString()}`;
+}
+
+/**
+ * WebP-via-weserv for LARGE images only (detail drawer header, ~50 KB →
+ * ~20 KB). Thumbnails stay on the direct Steam capsule URLs: they're already
+ * ~10 KB, SW-cached, and putting a third-party proxy in the hottest render
+ * path isn't worth ~5 KB/image (weserv downtime would degrade the whole
+ * table). If thumbnails ever get proxied, do it behind a Settings toggle.
+ *
+ * Desktop (Tauri) always gets the direct URL — the bundled app shouldn't
+ * leak browsing signals to a third-party CDN, and offline-first matters
+ * more there. Callers should pair this with an onError fallback to the
+ * original URL for weserv outages.
+ */
+export function preferWebp(url: string, width?: number): string {
+  if (!url || isTauri()) return url;
+  return webpProxyUrl(url, width);
 }

--- a/web/src/lib/lazy.ts
+++ b/web/src/lib/lazy.ts
@@ -1,0 +1,71 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+
+/**
+ * React.lazy wrapper that survives a deploy happening mid-session.
+ *
+ * After a new deploy the old hashed chunk files are gone; a user with a stale
+ * app shell who navigates to a not-yet-loaded route gets a network/import
+ * error. We auto-reload ONCE per tab (sessionStorage flag — must not survive
+ * the tab, or a genuinely broken deploy would never surface its error UI).
+ * The reload also picks up the waiting service worker, so the second attempt
+ * imports from the fresh precache. A second failure throws to the nearest
+ * ErrorBoundary.
+ */
+
+const RELOAD_FLAG = "f2p:chunk-reload";
+
+/** Detects "failed to fetch dynamically imported module" / chunk 404s. */
+export function isChunkLoadError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    /failed to fetch dynamically imported module|importing a module script failed|error loading dynamically imported module/i.test(
+      err.message,
+    )
+  );
+}
+
+// Tauri webviews / lockdown modes can block sessionStorage — degrade to
+// "no retry" rather than crashing the lazy factory.
+function getFlag(): boolean {
+  try {
+    return sessionStorage.getItem(RELOAD_FLAG) !== null;
+  } catch {
+    return true; // pretend already retried → skip the reload path
+  }
+}
+
+function setFlag(): void {
+  try {
+    sessionStorage.setItem(RELOAD_FLAG, "1");
+  } catch {
+    /* ignore */
+  }
+}
+
+function clearFlag(): void {
+  try {
+    sessionStorage.removeItem(RELOAD_FLAG);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function lazyWithRetry<T extends ComponentType<any>>(
+  importer: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  return lazy(async () => {
+    try {
+      const mod = await importer();
+      clearFlag();
+      return mod;
+    } catch (err) {
+      if (isChunkLoadError(err) && !getFlag()) {
+        setFlag();
+        window.location.reload();
+        // Keep the Suspense fallback up while the reload happens.
+        return new Promise<never>(() => {});
+      }
+      throw err;
+    }
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,7 +4,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HashRouter } from "react-router-dom";
 import { Toaster } from "sonner";
 import App from "./App";
-import "./i18n";
+import { AppErrorBoundary } from "./components/common/AppErrorBoundary";
+import { initI18n } from "./i18n";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -18,25 +19,37 @@ const queryClient = new QueryClient({
   },
 });
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <HashRouter>
-        <App />
-        <Toaster
-          richColors
-          closeButton
-          theme="dark"
-          position="bottom-right"
-          toastOptions={{
-            style: {
-              background: "hsl(var(--card))",
-              color: "hsl(var(--card-foreground))",
-              border: "1px solid hsl(var(--border))",
-            },
-          }}
-        />
-      </HashRouter>
-    </QueryClientProvider>
-  </React.StrictMode>,
-);
+function renderApp() {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <AppErrorBoundary>
+        <QueryClientProvider client={queryClient}>
+          <HashRouter>
+            <App />
+            <Toaster
+              richColors
+              closeButton
+              theme="dark"
+              position="bottom-right"
+              toastOptions={{
+                style: {
+                  background: "hsl(var(--card))",
+                  color: "hsl(var(--card-foreground))",
+                  border: "1px solid hsl(var(--border))",
+                },
+              }}
+            />
+          </HashRouter>
+        </QueryClientProvider>
+      </AppErrorBoundary>
+    </React.StrictMode>,
+  );
+}
+
+// Await i18n (incl. the lazy locale bundle) before first render so t() never
+// flashes raw keys. `.finally` guarantees render even if init rejects — en
+// resources are bundled, so the app still works in the fallback language.
+// Async bootstrap instead of top-level await: build.target is es2020.
+initI18n()
+  .catch((err) => console.error("[i18n] init failed:", err))
+  .finally(renderApp);

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -295,6 +295,7 @@ export function AboutPage() {
                     width={32}
                     height={32}
                     loading="lazy"
+                    decoding="async"
                     className="h-8 w-8 rounded bg-white p-0.5"
                     title="Scan to open in Telegram"
                   />
@@ -391,6 +392,7 @@ export function AboutPage() {
                 width={200}
                 height={200}
                 loading="lazy"
+                decoding="async"
                 className="h-40 w-40 rounded bg-white p-2"
               />
               <div className="text-center">
@@ -410,6 +412,7 @@ export function AboutPage() {
                 width={200}
                 height={200}
                 loading="lazy"
+                decoding="async"
                 className="h-40 w-40 rounded bg-white p-2"
               />
               <div className="text-center">

--- a/web/src/pages/Activity.tsx
+++ b/web/src/pages/Activity.tsx
@@ -74,7 +74,7 @@ export function ActivityPage() {
   }, [q.data, filter, auth.user?.login]);
 
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error as Error} />;
+  if (q.error) return <ErrorState error={q.error as Error} onRetry={() => void q.refetch()} />;
 
   return (
     <div className="space-y-4">
@@ -142,6 +142,8 @@ function CommitRow({ commit }: { commit: Commit }) {
           <img
             src={commit.author.avatar_url}
             alt=""
+            loading="lazy"
+            decoding="async"
             className={cn(
               "h-7 w-7 rounded-full border",
               isBot && "ring-1 ring-amber-500/40",

--- a/web/src/pages/AntiCheatList.tsx
+++ b/web/src/pages/AntiCheatList.tsx
@@ -77,7 +77,7 @@ export function AntiCheatListPage() {
   }, [q.data]);
 
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   const total = buckets.reduce((s, b) => s + b.games.length, 0);

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -15,7 +15,7 @@ export function Dashboard() {
   const q = useGames();
   const removed = useRemovedGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   const { records, index } = q.data;

--- a/web/src/pages/Games.tsx
+++ b/web/src/pages/Games.tsx
@@ -56,7 +56,7 @@ export function GamesPage() {
   }, [searchParams, setSearch]);
 
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   const hasFilter = genre || typeGame || platform || status || hideDead;

--- a/web/src/pages/Health.tsx
+++ b/web/src/pages/Health.tsx
@@ -88,7 +88,7 @@ export function HealthPage() {
   const issues = useMemo(() => (q.data ? gatherIssues(q.data.records) : []), [q.data]);
 
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   const totalIssues = issues.reduce((sum, g) => sum + g.records.length, 0);

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -75,7 +75,9 @@ export function SettingsPage() {
                   variant={active ? "default" : "outline"}
                   size="sm"
                   onClick={() => {
-                    setLanguage(code);
+                    // Async: loads the locale bundle before switching. The
+                    // languageChanged listener above re-syncs local state.
+                    void setLanguage(code);
                     setLang(code);
                   }}
                 >

--- a/web/src/pages/TopOffline.tsx
+++ b/web/src/pages/TopOffline.tsx
@@ -10,7 +10,7 @@ export function TopOfflinePage() {
   useDocumentTitle("topOffline.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/TopOnline.tsx
+++ b/web/src/pages/TopOnline.tsx
@@ -10,7 +10,7 @@ export function TopOnlinePage() {
   useDocumentTitle("topOnline.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/AntiCheat.tsx
+++ b/web/src/pages/charts/AntiCheat.tsx
@@ -10,7 +10,7 @@ export function AntiCheatPage() {
   useDocumentTitle("charts.antiCheat.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Delisted.tsx
+++ b/web/src/pages/charts/Delisted.tsx
@@ -11,7 +11,7 @@ export function DelistedPage() {
   useDocumentTitle("charts.delisted.title");
   const q = useRemovedGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Drm.tsx
+++ b/web/src/pages/charts/Drm.tsx
@@ -10,7 +10,7 @@ export function DrmPage() {
   useDocumentTitle("charts.drm.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Genres.tsx
+++ b/web/src/pages/charts/Genres.tsx
@@ -10,7 +10,7 @@ export function GenresPage() {
   useDocumentTitle("charts.genres.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Languages.tsx
+++ b/web/src/pages/charts/Languages.tsx
@@ -10,7 +10,7 @@ export function LanguagesPage() {
   useDocumentTitle("charts.languages.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Platforms.tsx
+++ b/web/src/pages/charts/Platforms.tsx
@@ -10,7 +10,7 @@ export function PlatformsPage() {
   useDocumentTitle("charts.platforms.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Players.tsx
+++ b/web/src/pages/charts/Players.tsx
@@ -10,7 +10,7 @@ export function PlayersPage() {
   useDocumentTitle("charts.players.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Reviews.tsx
+++ b/web/src/pages/charts/Reviews.tsx
@@ -10,7 +10,7 @@ export function ReviewsPage() {
   useDocumentTitle("charts.reviews.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Tags.tsx
+++ b/web/src/pages/charts/Tags.tsx
@@ -10,7 +10,7 @@ export function TagsPage() {
   useDocumentTitle("charts.tags.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/charts/Time.tsx
+++ b/web/src/pages/charts/Time.tsx
@@ -12,7 +12,7 @@ export function TimePage() {
   useDocumentTitle("charts.time.title");
   const q = useGames();
   if (q.isLoading) return <LoadingState />;
-  if (q.error) return <ErrorState error={q.error} />;
+  if (q.error) return <ErrorState error={q.error} onRetry={() => void q.refetch()} />;
   if (!q.data) return null;
 
   return (

--- a/web/src/pages/errors/ErrorCodeRoute.tsx
+++ b/web/src/pages/errors/ErrorCodeRoute.tsx
@@ -1,0 +1,13 @@
+import { useParams } from "react-router-dom";
+import { ERROR_CODES, ErrorPage, type ErrorCode } from "./ErrorPage";
+
+/**
+ * #/error/:code — deep-linkable error pages (403/404/419/5xx/offline).
+ * Unknown codes render the 404 page in place (no redirect — preserves the
+ * URL for debugging and avoids redirect-loop bugs).
+ */
+export function ErrorCodeRoute() {
+  const { code } = useParams();
+  const valid = (ERROR_CODES as readonly string[]).includes(code ?? "");
+  return <ErrorPage code={valid ? (code as ErrorCode) : "404"} />;
+}

--- a/web/src/pages/errors/ErrorPage.tsx
+++ b/web/src/pages/errors/ErrorPage.tsx
@@ -1,0 +1,108 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  ShieldX,
+  FileQuestion,
+  TimerOff,
+  ServerCrash,
+  Network,
+  CloudOff,
+  Hourglass,
+  WifiOff,
+  Home,
+  RotateCw,
+  Bug,
+  type LucideIcon,
+} from "lucide-react";
+import { Button } from "../../components/ui/button";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+
+/**
+ * Shared error page for SPA-level errors. GitHub Pages can't serve real
+ * per-status error documents (only 404.html), so 403/419/5xx here are
+ * app-level: rendered by the router (#/error/:code), the route ErrorBoundary
+ * (500/503), or deep links. Kept in the EAGER bundle on purpose — the error
+ * UI must not live in a lazy chunk, or a chunk-load failure couldn't render
+ * its own error page.
+ */
+
+export const ERROR_CODES = [
+  "403",
+  "404",
+  "419",
+  "500",
+  "502",
+  "503",
+  "504",
+  "offline",
+] as const;
+export type ErrorCode = (typeof ERROR_CODES)[number];
+
+const META: Record<ErrorCode, { icon: LucideIcon; tone: "neutral" | "warn" | "destructive" }> = {
+  "403": { icon: ShieldX, tone: "warn" },
+  "404": { icon: FileQuestion, tone: "neutral" },
+  "419": { icon: TimerOff, tone: "warn" },
+  "500": { icon: ServerCrash, tone: "destructive" },
+  "502": { icon: Network, tone: "destructive" },
+  "503": { icon: CloudOff, tone: "destructive" },
+  "504": { icon: Hourglass, tone: "destructive" },
+  offline: { icon: WifiOff, tone: "warn" },
+};
+
+export const REPORT_ISSUE_URL =
+  "https://github.com/poli0981/free-steam-games-list/issues/new";
+
+interface Props {
+  code: ErrorCode;
+  /** Optional technical detail line (error message, hint). */
+  detail?: string;
+}
+
+export function ErrorPage({ code, detail }: Props) {
+  const { t } = useTranslation();
+  useDocumentTitle(`errors.${code}.title`);
+  const { icon: Icon, tone } = META[code];
+  const toneCls =
+    tone === "destructive"
+      ? "border-destructive/40 bg-destructive/5 text-destructive"
+      : tone === "warn"
+        ? "border-amber-500/30 bg-amber-500/10 text-amber-400"
+        : "border-border bg-card text-muted-foreground";
+  return (
+    <div className="flex h-[60vh] items-center justify-center">
+      <div className={`max-w-md rounded-lg border p-8 text-center ${toneCls}`}>
+        <Icon className="mx-auto mb-4 h-10 w-10" />
+        <p className="font-mono text-xs tracking-widest opacity-70">
+          {code === "offline" ? t("errors.offline.badge") : t("errors.code", { code })}
+        </p>
+        <h1 className="mb-2 mt-1 text-xl font-semibold text-foreground">
+          {t(`errors.${code}.title`)}
+        </h1>
+        <p className="text-sm text-muted-foreground">{t(`errors.${code}.description`)}</p>
+        {detail && (
+          <p className="mt-2 break-words font-mono text-xs text-muted-foreground/70">
+            {detail}
+          </p>
+        )}
+        <div className="mt-6 flex flex-wrap justify-center gap-2">
+          <Button asChild size="sm">
+            <Link to="/">
+              <Home className="mr-1 h-3.5 w-3.5" />
+              {t("errors.actions.home")}
+            </Link>
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => window.location.reload()}>
+            <RotateCw className="mr-1 h-3.5 w-3.5" />
+            {t("errors.actions.reload")}
+          </Button>
+          <Button asChild size="sm" variant="ghost">
+            <a href={REPORT_ISSUE_URL} target="_blank" rel="noreferrer">
+              <Bug className="mr-1 h-3.5 w-3.5" />
+              {t("errors.actions.report")}
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/errors/NotFound.tsx
+++ b/web/src/pages/errors/NotFound.tsx
@@ -1,0 +1,6 @@
+import { ErrorPage } from "./ErrorPage";
+
+/** Catch-all route — replaces the old silent redirect-to-home. */
+export function NotFoundPage() {
+  return <ErrorPage code="404" />;
+}

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+import { toast } from "sonner";
+import i18n from "../i18n";
 import {
   loadAuth,
   saveAuth,
@@ -56,6 +58,20 @@ export const useAuth = create<AuthStore>((set, get) => ({
         user: null,
       });
       clearAuth();
+      // A previously-saved token failing verification = session expired
+      // (419 semantics). Toast instead of routing to #/error/419 — don't
+      // hijack whatever page the user opened. 10s duration: the default 4s
+      // is too short for a toast carrying an action button.
+      toast.error(i18n.t("errors.419.title"), {
+        description: i18n.t("errors.419.description"),
+        duration: 10000,
+        action: {
+          label: i18n.t("errors.actions.openSettings"),
+          onClick: () => {
+            window.location.hash = "#/settings";
+          },
+        },
+      });
     }
   },
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,14 +1,24 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
+import { visualizer } from "rollup-plugin-visualizer";
 import path from "node:path";
 
 const repoName = "free-steam-games-list";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command, mode }) => ({
   base: command === "build" ? `/${repoName}/` : "/",
   plugins: [
     react(),
+    // `npm run analyze` → dist/stats.html treemap. Vite mode instead of an
+    // env var so it works cross-platform without cross-env.
+    mode === "analyze" &&
+      visualizer({
+        filename: "dist/stats.html",
+        gzipSize: true,
+        brotliSize: true,
+        template: "treemap",
+      }),
     VitePWA({
       registerType: "autoUpdate",
       injectRegister: "auto",
@@ -43,6 +53,10 @@ export default defineConfig(({ command }) => ({
         // Precache the app shell. Bigger than default to fit echarts + openpgp chunks.
         maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
         globPatterns: ["**/*.{js,css,html,svg,woff2}"],
+        // 404.html is GitHub Pages' error document for paths outside the
+        // SPA — precaching it would be wasted bytes (SW-controlled clients
+        // get navigateFallback to index.html and never see it).
+        globIgnores: ["404.html"],
         navigateFallback: command === "build" ? `/${repoName}/index.html` : "/index.html",
         runtimeCaching: [
           // Raw shard data — NetworkFirst so an edit lands on disk → next page
@@ -118,12 +132,16 @@ export default defineConfig(({ command }) => ({
     chunkSizeWarningLimit: 1200,
     rollupOptions: {
       output: {
+        // echarts/openpgp are NOT listed here on purpose: they're behind
+        // dynamic-import boundaries (LazyEChart, lib/gpg pgp()) and Rollup
+        // splits them naturally. Forcing them into manual chunks made
+        // Rollup hoist shared helpers (tslib) INTO the echarts chunk, which
+        // the eager graph then statically imported — echarts ended up
+        // modulepreloaded on first paint, nullifying the lazy boundary.
         manualChunks: {
           react: ["react", "react-dom", "react-router-dom"],
           query: ["@tanstack/react-query"],
           table: ["@tanstack/react-virtual"],
-          echarts: ["echarts", "echarts-for-react"],
-          openpgp: ["openpgp"],
         },
       },
     },


### PR DESCRIPTION
## Summary

Two feature groups for v3.3.0:

### ⚡ Performance (lazy-load everything heavy)
- Route-level code splitting (`lazyWithRetry`, Suspense inside Layout — shell stays mounted)
- echarts (~666 KB) behind a `LazyEChart` dynamic boundary; openpgp (~391 KB) behind a memoized dynamic import (visitors without a GPG key never download it)
- Per-locale i18n: `vi.json` lazy, `en` stays bundled as fallback; `initI18n()` awaited before first render (no raw-key flash)
- Removed `echarts`/`openpgp` from `manualChunks` — tslib hoisting was making the eager graph modulepreload echarts, nullifying the lazy boundary
- `decoding="async"` sweep, `preferWebp` for the drawer header image (direct Steam URL on Tauri, onError fallback), `useDeferredValue` search, preconnect hints, `npm run analyze` (rollup-plugin-visualizer)

**First-load JS: ~574 KB → ~163 KB gzip (−72%).** `dist/index.html` now modulepreloads only `react` + `query`.

### 🚦 Error pages (403/404/419/5xx/offline)
- Config-driven `ErrorPage` + `#/error/:code` deep links + real 404 catch-all (was a silent redirect to home)
- `ErrorBoundary` route-level (chunk-error → 503 "new deploy, reload"; crash → 500) + top-level `AppErrorBoundary` (inline styles, bilingual hardcoded strings — immune to i18n/router failure)
- GitHub Pages `404.html` (standalone, bilingual, noindex, excluded from SW precache)
- `ErrorState` offline copy + Retry/Report actions wired at 17 call sites; 419 toast with "Open Settings" on expired token
- Full en/vi translations for all error copy

### 📦 Release plumbing
- Web/desktop `1.2.7 → 1.3.0` (Cargo.lock synced), repo `3.2.7 → 3.3.0`, CHANGELOG entry
- `npm audit fix`: react-router GHSA-2j2x-hqr9-3h42 → 0 vulnerabilities

## Test plan
- [x] `npm run typecheck` / `build` / `knip` (back to 45/21 warn baseline, exit 0) / `npm audit` (0) — web/
- [x] `vulture` + `pip-audit` (clean) — root
- [x] Smoke test (dev server): `#/error/403` (amber card), `#/garbage` → 404, `#/error/999` → 404, vi + en copy, hard reload with `f2p:lang=vi` (no key flash), Dashboard data, Tags word-cloud (echarts lazy path)
- [x] `dist/sw.js` has no `404.html` precache entry; only react+query modulepreloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)