### PR TITLE
v3.4.0: legal consent gate (web first-run + Windows installer license page)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.4.0] – 2026-06-13 (The "Legal Consent Gate" Edition)
+
+Feature release on top of v3.3.0 adding an explicit, up-front acceptance of the project's legal documents on both surfaces: a first-run consent gate in the app (web + desktop) and a real license-agreement page in the Windows installer. No backend, no cookies — acceptance is a single `localStorage` flag, versioned so it can re-prompt when the terms change, and naturally fresh in incognito/private tabs. Web app + desktop bumped `1.3.0` → `1.4.0`. Repo public-facing version `3.3.0` → `3.4.0`. Tag `v3.4.0` is GPG-signed; companion desktop tag is `desktop-v1.4.0`.
+
+### ⚖️ First-run consent gate (web + desktop)
+
+- New [ConsentGate.tsx](web/src/components/common/ConsentGate.tsx) — a full-screen card (styled like the error pages, eager bundle, no flash) that blocks the main UI until the user ticks a checkbox and clicks **Continue**. Mounted inside `AppErrorBoundary` + `HashRouter` in [main.tsx](web/src/main.tsx), wrapping `<App/>` (the `<Toaster/>` stays a sibling). A gate crash is still caught by the top-level boundary.
+- **Decline path** — explicit **Decline** button: on desktop (Tauri) it quits the app via `getCurrentWindow().close()`; on web it shows a blocking "you need to accept" notice with a way back to the gate.
+- **Persistence** — new [stores/consent.ts](web/src/stores/consent.ts) (Zustand, same pattern as `stores/gpg.ts`): `localStorage` key `f2p:legal_consent` holding `{ version, acceptedAt }`. A `TERMS_VERSION` constant gates validity — bump it when the legal docs change materially and everyone is re-prompted. Incognito tabs get a fresh storage partition, so the gate re-shows there with zero extra code. No cookie is used anywhere (there is no server to read one).
+- **Error routes pass through** — the gate lets `#/error/*` render even before consent, so a mid-session chunk-load 503, the Pages `404.html` redirect, or an `#/error/:code` deep link still reaches the user instead of being swallowed.
+- **Doc links** — the gate's five binding documents (MIT License, EULA, Privacy Policy, Disclaimer, Terms of Use) open through the existing [external-open.ts](web/src/lib/external-open.ts) `openExternal()` helper, so they work inside the Tauri webview (which blocks `window.open` to external HTTPS) as well as on the web.
+- **Shared legal list** — the `LEGAL_DOCS` array (label / path / hint) was lifted out of [About.tsx](web/src/pages/About.tsx) into a reusable [lib/legal.ts](web/src/lib/legal.ts) (`LEGAL_DOCS`, `CONSENT_DOCS`, `legalDocUrl()`); About now imports it instead of holding a private copy.
+- New `consent.*` i18n keys added to both [en.json](web/src/i18n/locales/en.json) and [vi.json](web/src/i18n/locales/vi.json). Long-form legal copy stays English (the doc labels come from `LEGAL_DOCS`); only the gate chrome is bilingual.
+
+### 🪟 Windows installer license page
+
+- [tauri.conf.json](web/src-tauri/tauri.conf.json) now sets `bundle.licenseFile` to a new [LICENSE_AGREEMENT.rtf](web/src-tauri/LICENSE_AGREEMENT.rtf). Tauri v2 surfaces this as a mandatory "I Agree" license page in **both** Windows targets built by `targets: "all"` — the NSIS `-setup.exe` (MUI license page) and the WiX `.msi` (which requires RTF). The RTF is plain ASCII with no BOM to avoid the known NSIS license-encoding bug.
+- The installer gate (install-time, desktop-only) and the in-app gate (first-run, web + desktop, re-promptable) are intentionally both kept: the auto-updater replaces the binary without re-running the installer, so the in-app `TERMS_VERSION` mechanism is the only way to re-prompt updated installs.
+- Desktop window-close on decline needs the `core:window:allow-close` permission, now added to [capabilities/default.json](web/src-tauri/capabilities/default.json). New dependency `@tauri-apps/api` (official, lazy-imported only on the desktop decline path — no web-bundle bloat).
+
+### 🧰 Tooling & misc
+
+- Version bumped across the three desktop files ([web/package.json](web/package.json), [tauri.conf.json](web/src-tauri/tauri.conf.json), [Cargo.toml](web/src-tauri/Cargo.toml)) → `1.4.0`; the stale README version badge corrected `3.2.7` → `3.4.0`.
+- Pre-publish suite (`typecheck`, `knip`, `npm audit`, `vulture`, `pip-audit`) re-run clean.
+
 ## [v3.3.0] – 2026-06-12 (The "Lazy-Load + Error Pages" Edition)
 
 Feature release on top of v3.2.7, two themes: a web-app performance overhaul (route-level code splitting, lazy echarts/openpgp/locale chunks — first-load JS drops from ~574 KB to ~163 KB gzipped, −72%) and a proper error-page system (403/404/419/5xx/offline pages, React error boundaries, a real GitHub Pages `404.html`). Web app + desktop bumped `1.2.7` → `1.3.0`. Repo public-facing version `3.2.7` → `3.3.0`. Tag `v3.3.0` is GPG-signed; companion desktop tag is `desktop-v1.3.0`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.2.7-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.4.0-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.2.7",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.2.7",
+      "version": "1.4.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",
@@ -15,6 +15,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@tanstack/react-query": "^5.59.0",
         "@tanstack/react-virtual": "^3.10.8",
+        "@tauri-apps/api": "^2.1.0",
         "@tauri-apps/plugin-shell": "^2.0.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -23,6 +23,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-virtual": "^3.10.8",
+    "@tauri-apps/api": "^2.1.0",
     "@tauri-apps/plugin-shell": "^2.0.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.3.0"
+version = "1.4.0"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/LICENSE_AGREEMENT.rtf
+++ b/web/src-tauri/LICENSE_AGREEMENT.rtf
@@ -1,0 +1,16 @@
+{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil\fcharset0 Segoe UI;}}
+\f0\fs20
+{\b F2P Tracker \endash  License Agreement}\par
+\par
+By installing and using F2P Tracker you accept and agree to be bound by the following documents:\par
+\par
+- MIT License: https://github.com/poli0981/free-steam-games-list/blob/main/LICENSE\par
+- End User License Agreement (EULA): https://github.com/poli0981/free-steam-games-list/blob/main/docs/EULA.md\par
+- Privacy Policy: https://github.com/poli0981/free-steam-games-list/blob/main/docs/PRIVACY_POLICY.md\par
+- Disclaimer: https://github.com/poli0981/free-steam-games-list/blob/main/docs/DISCLAIMER.md\par
+- Terms of Use: https://github.com/poli0981/free-steam-games-list/blob/main/docs/ToS.md\par
+\par
+F2P Tracker is an independent, MIT-licensed project. It is not affiliated with Valve or Steam. The app collects no telemetry; catalogue data is read live from raw.githubusercontent.com. The software is provided "AS IS", without warranty of any kind.\par
+\par
+If you do not agree to these terms, do not install or use this software.\par
+}

--- a/web/src-tauri/capabilities/default.json
+++ b/web/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-close",
     "shell:allow-open",
     "updater:default"
   ]

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",
@@ -51,7 +51,8 @@
     "longDescription": "Desktop wrapper around the Steam F2P Tracker web app. Browses 1,200+ free-to-play games with charts, filters, and editor. Reads data live from raw.githubusercontent.com; no telemetry.",
     "publisher": "poli0981",
     "homepage": "https://github.com/poli0981/free-steam-games-list",
-    "license": "MIT"
+    "license": "MIT",
+    "licenseFile": "LICENSE_AGREEMENT.rtf"
   },
   "plugins": {
     "updater": {

--- a/web/src/components/common/ConsentGate.tsx
+++ b/web/src/components/common/ConsentGate.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { ScrollText, ExternalLink, ShieldCheck } from "lucide-react";
+import { Button } from "../ui/button";
+import { useConsent } from "../../stores/consent";
+import { CONSENT_DOCS, legalDocUrl } from "../../lib/legal";
+import { isTauri, openExternal } from "../../lib/external-open";
+
+/**
+ * First-run legal consent gate. Blocks the main UI until the user accepts the
+ * binding documents. Kept in the EAGER bundle (no lazy import) so it paints on
+ * first render with no flash — i18n is already awaited before render in
+ * main.tsx. Mounted INSIDE AppErrorBoundary + HashRouter, so a crash here is
+ * caught by the top-level boundary and `useLocation` is available.
+ *
+ * Persistence + incognito behaviour live in stores/consent.ts.
+ */
+export function ConsentGate({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation();
+  const accepted = useConsent((s) => s.accepted);
+  const accept = useConsent((s) => s.accept);
+  const location = useLocation();
+  const [checked, setChecked] = useState(false);
+  const [declined, setDeclined] = useState(false);
+
+  // Let the error system through even before consent: a chunk-load 503 after a
+  // mid-session deploy, the GitHub Pages 404.html redirect, or an #/error/:code
+  // deep link must reach the user instead of being swallowed behind the gate.
+  const isErrorRoute = location.pathname.startsWith("/error");
+
+  if (accepted || isErrorRoute) return <>{children}</>;
+
+  function handleDecline() {
+    // Desktop: declining means you don't get the app — quit it. On web there's
+    // nothing to quit, so show a blocking notice with a way back to the gate.
+    if (isTauri()) {
+      void (async () => {
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          await getCurrentWindow().close();
+        } catch (err) {
+          console.error("ConsentGate: failed to close window", err);
+          setDeclined(true);
+        }
+      })();
+    } else {
+      setDeclined(true);
+    }
+  }
+
+  if (declined) {
+    return (
+      <div className="flex min-h-screen items-center justify-center overflow-auto p-4">
+        <div className="w-full max-w-md rounded-lg border border-amber-500/30 bg-amber-500/5 p-8 text-center">
+          <ShieldCheck className="mx-auto mb-4 h-10 w-10 text-amber-400" />
+          <h1 className="mb-2 text-xl font-semibold text-foreground">
+            {t("consent.declinedTitle")}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t("consent.declinedBody")}</p>
+          <div className="mt-6">
+            <Button size="sm" onClick={() => setDeclined(false)}>
+              {t("consent.back")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center overflow-auto p-4">
+      <div className="w-full max-w-lg rounded-lg border border-border bg-card p-8 text-foreground">
+        <ScrollText className="mb-4 h-10 w-10 text-primary" />
+        <h1 className="text-xl font-semibold">{t("consent.title")}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{t("consent.intro")}</p>
+
+        <p className="mt-5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {t("consent.docsLabel")}
+        </p>
+        <ul className="mt-2 space-y-1.5">
+          {CONSENT_DOCS.map((d) => (
+            <li key={d.path}>
+              <button
+                type="button"
+                onClick={() => void openExternal(legalDocUrl(d.path))}
+                className="flex w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+              >
+                <span className="font-medium">{d.label}</span>
+                <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <label className="mt-6 flex cursor-pointer items-start gap-2.5 text-sm">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+            className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-primary"
+          />
+          <span className="text-muted-foreground">{t("consent.checkboxLabel")}</span>
+        </label>
+
+        <div className="mt-6 flex flex-wrap gap-2">
+          <Button disabled={!checked} onClick={() => accept()}>
+            {t("consent.continue")}
+          </Button>
+          <Button variant="ghost" onClick={handleDecline}>
+            {t("consent.decline")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,4 +1,15 @@
 {
+  "consent": {
+    "title": "Before you continue",
+    "intro": "By using this site you accept and agree to be bound by the documents below. Open any of them to read the full text.",
+    "docsLabel": "Legal documents",
+    "checkboxLabel": "I have read and accept the License, EULA, Privacy Policy, Disclaimer, and Terms of Use.",
+    "continue": "Continue",
+    "decline": "Decline",
+    "declinedTitle": "You need to accept the terms",
+    "declinedBody": "You must accept the License, EULA, Privacy Policy, Disclaimer, and Terms of Use to use F2P Tracker.",
+    "back": "Back"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "games": "Games",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1,4 +1,15 @@
 {
+  "consent": {
+    "title": "Trước khi tiếp tục",
+    "intro": "Khi sử dụng trang này, bạn chấp nhận và đồng ý tuân thủ các văn bản dưới đây. Bấm vào từng mục để đọc toàn văn.",
+    "docsLabel": "Văn bản pháp lý",
+    "checkboxLabel": "Tôi đã đọc và chấp nhận License, EULA, Chính sách bảo mật, Tuyên bố miễn trừ và Điều khoản sử dụng.",
+    "continue": "Tiếp tục",
+    "decline": "Từ chối",
+    "declinedTitle": "Bạn cần chấp nhận điều khoản",
+    "declinedBody": "Bạn phải chấp nhận License, EULA, Chính sách bảo mật, Tuyên bố miễn trừ và Điều khoản sử dụng để dùng F2P Tracker.",
+    "back": "Quay lại"
+  },
   "nav": {
     "dashboard": "Tổng quan",
     "games": "Trò chơi",

--- a/web/src/lib/legal.ts
+++ b/web/src/lib/legal.ts
@@ -1,0 +1,35 @@
+import { REPO_OWNER, REPO_NAME } from "./schema";
+
+/**
+ * Single source of truth for the project's legal documents.
+ *
+ * Lifted out of About.tsx so the first-run consent gate and the About page
+ * render the same list. Long-form legal bodies stay in English (markdown in
+ * the repo `docs/` folder); only the surrounding UI chrome is translated.
+ */
+export interface LegalDoc {
+  label: string;
+  /** Path relative to the repo root, e.g. "docs/EULA.md" or "LICENSE". */
+  path: string;
+  hint: string;
+  /** True for the binding documents shown in the consent gate checkbox flow. */
+  consent?: boolean;
+}
+
+export const LEGAL_DOCS: LegalDoc[] = [
+  { label: "MIT License", path: "LICENSE", hint: "the actual binding terms — short and friendly", consent: true },
+  { label: "Disclaimer", path: "docs/DISCLAIMER.md", hint: "no warranty, accuracy caveats, liability shrug", consent: true },
+  { label: "Terms of Use", path: "docs/ToS.md", hint: "what you agree to by using the repo / site", consent: true },
+  { label: "EULA", path: "docs/EULA.md", hint: "redundant with MIT but exists for paranoia", consent: true },
+  { label: "Privacy Policy", path: "docs/PRIVACY_POLICY.md", hint: "no data collected by the site itself", consent: true },
+  { label: "Acknowledgements", path: "docs/ACKNOWLEDGEMENTs.md", hint: "credits to AI assistants + contributors" },
+  { label: "Contact", path: "docs/Contact.md", hint: "where to find me" },
+];
+
+/** The 5 binding documents the user accepts at the consent gate. */
+export const CONSENT_DOCS: LegalDoc[] = LEGAL_DOCS.filter((d) => d.consent);
+
+/** Canonical GitHub URL for a legal doc, matching the About page's links. */
+export function legalDocUrl(path: string): string {
+  return `https://github.com/${REPO_OWNER}/${REPO_NAME}/blob/main/${path}`;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,7 @@ import { HashRouter } from "react-router-dom";
 import { Toaster } from "sonner";
 import App from "./App";
 import { AppErrorBoundary } from "./components/common/AppErrorBoundary";
+import { ConsentGate } from "./components/common/ConsentGate";
 import { initI18n } from "./i18n";
 import "./index.css";
 
@@ -25,7 +26,9 @@ function renderApp() {
       <AppErrorBoundary>
         <QueryClientProvider client={queryClient}>
           <HashRouter>
-            <App />
+            <ConsentGate>
+              <App />
+            </ConsentGate>
             <Toaster
               richColors
               closeButton

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -27,6 +27,7 @@ import { Separator } from "../components/ui/separator";
 import { useGames } from "../hooks/useGames";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { REPO_OWNER, REPO_NAME } from "../lib/schema";
+import { LEGAL_DOCS } from "../lib/legal";
 import { formatNumber } from "../lib/utils";
 
 const REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
@@ -101,22 +102,6 @@ const ISSUE_TEMPLATES = [
   { id: "add_games", label: "Add games", icon: PlusCircle, color: "text-emerald-400" },
   { id: "delete_game", label: "Delete game", icon: Shield, color: "text-violet-400" },
   { id: "feedback", label: "Feedback", icon: MessageCircle, color: "text-blue-400" },
-];
-
-interface LegalDoc {
-  label: string;
-  path: string;
-  hint: string;
-}
-
-const LEGAL_DOCS: LegalDoc[] = [
-  { label: "MIT License", path: "LICENSE", hint: "the actual binding terms — short and friendly" },
-  { label: "Disclaimer", path: "docs/DISCLAIMER.md", hint: "no warranty, accuracy caveats, liability shrug" },
-  { label: "Terms of Use", path: "docs/ToS.md", hint: "what you agree to by using the repo / site" },
-  { label: "EULA", path: "docs/EULA.md", hint: "redundant with MIT but exists for paranoia" },
-  { label: "Privacy Policy", path: "docs/PRIVACY_POLICY.md", hint: "no data collected by the site itself" },
-  { label: "Acknowledgements", path: "docs/ACKNOWLEDGEMENTs.md", hint: "credits to AI assistants + contributors" },
-  { label: "Contact", path: "docs/Contact.md", hint: "where to find me" },
 ];
 
 export function AboutPage() {

--- a/web/src/stores/consent.ts
+++ b/web/src/stores/consent.ts
@@ -1,0 +1,57 @@
+/**
+ * Legal consent state: whether the user has accepted the current version of
+ * the terms. Persisted to localStorage (no backend, no cookie — same pattern
+ * as f2p:theme / f2p:lang / f2p:gpg_*). Incognito tabs get a fresh storage
+ * partition, so the gate naturally re-shows there with zero extra code.
+ */
+import { create } from "zustand";
+
+const KEY = "f2p:legal_consent";
+
+/**
+ * Bump this whenever the binding legal documents change materially. A stored
+ * acceptance for an older version no longer counts, so everyone is re-prompted.
+ */
+const TERMS_VERSION = 1;
+
+interface StoredConsent {
+  version: number;
+  /** ISO timestamp of acceptance — informational only. */
+  acceptedAt: string;
+}
+
+function loadConsent(): StoredConsent | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredConsent;
+    return typeof parsed?.version === "number" ? parsed : null;
+  } catch {
+    // Private mode / blocked storage / malformed JSON → treat as not accepted.
+    return null;
+  }
+}
+
+interface ConsentStore {
+  /** True only when the stored acceptance matches the current TERMS_VERSION. */
+  accepted: boolean;
+  accept: () => void;
+}
+
+const stored = loadConsent();
+
+export const useConsent = create<ConsentStore>((set) => ({
+  accepted: stored?.version === TERMS_VERSION,
+  accept: () => {
+    const value: StoredConsent = {
+      version: TERMS_VERSION,
+      acceptedAt: new Date().toISOString(),
+    };
+    try {
+      localStorage.setItem(KEY, JSON.stringify(value));
+    } catch {
+      // If storage is blocked the gate simply re-shows next load — acceptable.
+    }
+    set({ accepted: true });
+  },
+}));


### PR DESCRIPTION
## What

Adds an explicit, up-front acceptance of the project's legal documents on both surfaces.

### ⚖️ Web / in-app first-run consent gate (web + desktop)
- New `ConsentGate` wraps `<App/>` inside `HashRouter` (Toaster stays a sibling; gate sits under `AppErrorBoundary`). Full-screen card, checkbox-gated **Continue**.
- **Decline** button: desktop (Tauri) quits via `getCurrentWindow().close()`; web shows a blocking "you need to accept" notice with a way back.
- Persistence: `localStorage` key `f2p:legal_consent` `{ version, acceptedAt }`, gated by a `TERMS_VERSION` constant (bump → everyone re-prompted). **No cookie** (no backend). Incognito tabs re-show naturally (fresh storage partition).
- `#/error/*` routes pass through the gate (so chunk-load 503 / Pages 404.html / error deep-links still reach the user).
- Doc links open through the existing `openExternal()` helper → work inside the Tauri webview (which blocks `window.open` to external HTTPS).
- `LEGAL_DOCS` lifted out of `About.tsx` into shared `lib/legal.ts` (`LEGAL_DOCS`, `CONSENT_DOCS`, `legalDocUrl`); About now imports it. New `consent.*` i18n keys in `en.json` + `vi.json`.

### 🪟 Windows installer license page
- `bundle.licenseFile` → new `LICENSE_AGREEMENT.rtf` (ASCII, no BOM) → mandatory "I Agree" page on **both** NSIS `.exe` and WiX `.msi`.
- `@tauri-apps/api` dependency added (lazy-imported, desktop decline path only — no web-bundle bloat); `core:window:allow-close` capability.

### 🧰 Versioning
- Desktop `1.3.0 → 1.4.0` (`web/package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`); repo `3.3.0 → 3.4.0` (`CHANGELOG.md`, README badge — also corrects the stale `3.2.7`).

## Verification
- `npm run typecheck` ✅ · `npm run knip` ✅ (no new warnings) · `npm run build` ✅ (PWA precache OK; Tauri `window` API split into its own lazy chunk).
- `vulture scripts/` ✅ · `pip-audit -r requirements.txt` ✅ (0 vulns).
- `npm audit`: 3 high are **esbuild** (dev-only build tooling, transitive via vite; not in shipped artifacts). Fix requires a breaking `vite@7→8` upgrade — **deferred to a separate PR**, not bundled into this feature release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)