### PR TITLE
fix(web): migrate Vite config to Vite 8 / Rolldown — restore Pages deploy

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -132,16 +132,34 @@ export default defineConfig(({ command, mode }) => ({
     chunkSizeWarningLimit: 1200,
     rollupOptions: {
       output: {
-        // echarts/openpgp are NOT listed here on purpose: they're behind
-        // dynamic-import boundaries (LazyEChart, lib/gpg pgp()) and Rollup
-        // splits them naturally. Forcing them into manual chunks made
-        // Rollup hoist shared helpers (tslib) INTO the echarts chunk, which
-        // the eager graph then statically imported — echarts ended up
-        // modulepreloaded on first paint, nullifying the lazy boundary.
-        manualChunks: {
-          react: ["react", "react-dom", "react-router-dom"],
-          query: ["@tanstack/react-query"],
-          table: ["@tanstack/react-virtual"],
+        // echarts/openpgp are NOT grouped here on purpose: they're behind
+        // dynamic-import boundaries (LazyEChart, lib/gpg pgp()) and the
+        // bundler splits them into async chunks naturally. Forcing them into
+        // a manual chunk made the bundler hoist shared helpers (tslib) INTO
+        // the echarts chunk, which the eager graph then statically imported —
+        // echarts ended up modulepreloaded on first paint, nullifying the
+        // lazy boundary.
+        //
+        // Vite 8 uses Rolldown, which dropped the object form of
+        // `manualChunks`. `advancedChunks.groups` is the replacement: each
+        // group `test`s a module id and only the three vendor groups below
+        // are captured; everything else (incl. echarts/openpgp) falls back to
+        // Rolldown's default code splitting, preserving the lazy boundaries.
+        advancedChunks: {
+          groups: [
+            {
+              name: "react",
+              test: /[\\/]node_modules[\\/](react|react-dom|react-router-dom|react-router|scheduler)[\\/]/,
+            },
+            {
+              name: "query",
+              test: /[\\/]node_modules[\\/]@tanstack[\\/]react-query[\\/]/,
+            },
+            {
+              name: "table",
+              test: /[\\/]node_modules[\\/]@tanstack[\\/]react-virtual[\\/]/,
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
## Vấn đề

**Deploy Web (GitHub Pages)** fail ở **mọi** push từ ~07:51 (2026-06-14), khiến site live đứng yên từ ~04:53 (deploy auto-chạy trên mọi commit đụng `data/**`).

**Root cause:** [#92](https://github.com/poli0981/free-steam-games-list/pull/92) (mang tên "Bump esbuild") thực chất là major upgrade `vite 7→8` + `@vitejs/plugin-react 4→6`. Vite 8 đổi bundler sang **Rolldown**, vốn **bỏ object-form `manualChunks`** → `tsc -b` (bước Type check trong `deploy-pages.yml`) fail tại `vite.config.ts`.

## Fix

Thay object-form `manualChunks` bằng Rolldown `advancedChunks.groups`:
- Giữ 3 nhóm vendor: `react` / `query` / `table`.
- **Không** gom `echarts`/`openpgp` → giữ lazy boundary (đã verify: cả hai không bị `modulepreload` trong `dist/index.html`).

## esbuild advisory (GHSA-g7r4-m6w7-qqqr)

Chỉ ảnh hưởng dev server Windows. Dưới Vite 8 **esbuild đã bị gỡ khỏi tree** (`npm ci` báo **0 vulnerabilities**) → advisory tự giải quyết, không cần `overrides`.

## Verify (local)

- ✅ `npm ci` (0 vulnerabilities)
- ✅ `npm run typecheck` (bước CI đang fail)
- ✅ `npm run build` — echarts/openpgp ở async chunk riêng, không eager-load
- ✅ `npm run build:desktop`
- ✅ PWA service worker (`sw.js`) sinh ra OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)