### PR TITLE
v3.4.1: fix chart tabs (Rolldown CJS interop, React #130) + glib advisory note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.4.1] – 2026-06-14 (The "Chart Hotfix" Edition)
+
+Patch release fixing a production regression introduced by the Vite 8 / Rolldown deploy hotfix (#95): every chart tab threw a blank **React error #130** and failed to render. Web app + desktop bumped `1.4.0` → `1.4.1`; repo public-facing version `3.4.0` → `3.4.1`.
+
+### 🐛 Charts render again (React #130)
+
+- [EChart.tsx](web/src/components/charts/EChart.tsx) imported the chart wrapper from `echarts-for-react/lib/core` — the **CommonJS** build. Under Vite 8's Rolldown bundler the CJS default-interop wraps `module.exports = class` into a namespace object, so `<ReactEChartsCore/>` received an object instead of a component → React error #130 on **every** chart page (all [pages/charts/*](web/src/pages/charts) + the [Dashboard](web/src/pages/Dashboard.tsx)). Switched the import to the **ESM** build `echarts-for-react/esm/core`, which has a clean `export default`. echarts core and echarts-wordcloud were already ESM, so this single import was the only offender.
+- Verified at **runtime against the production (Rolldown) build** (the step skipped in #95): bar, pie/donut, line, treemap, heatmap and wordcloud charts all render with zero console errors. `echarts`/`openpgp` remain lazy async chunks (not eager-preloaded in `index.html`).
+
+### ⚠️ glib advisory (Linux desktop) — acknowledged, no upstream fix
+
+- The Dependabot alert for the `glib` crate ([GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g), medium, Linux-only) cannot be resolved within Tauri 2.x: the latest `webkit2gtk` crate (2.0.2) pins `glib ^0.18`, `tao`/`wry` pin `gtk ^0.18`, and Tauri 3 is not released. Only the Linux build links glib (Windows = WebView2, macOS = Cocoa) and the app does not call the affected API, so the alert is dismissed as tolerable risk. Will revisit when the upstream stack adopts gtk-rs 0.20. See [TAURI.md](web/src-tauri/TAURI.md).
+
 ## [v3.4.0] – 2026-06-13 (The "Legal Consent Gate" Edition)
 
 Feature release on top of v3.3.0 adding an explicit, up-front acceptance of the project's legal documents on both surfaces: a first-run consent gate in the app (web + desktop) and a real license-agreement page in the Windows installer. No backend, no cookies — acceptance is a single `localStorage` flag, versioned so it can re-prompt when the terms change, and naturally fresh in incognito/private tabs. Web app + desktop bumped `1.3.0` → `1.4.0`. Repo public-facing version `3.3.0` → `3.4.0`. Tag `v3.4.0` is GPG-signed; companion desktop tag is `desktop-v1.4.0`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.4.0-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.4.1-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.4.0"
+version = "1.4.1"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/TAURI.md
+++ b/web/src-tauri/TAURI.md
@@ -84,6 +84,10 @@ It runs the build matrix (Win / macOS-universal / Linux), uploads installers as 
 - **macOS universal binary** — ensure both `aarch64-apple-darwin` and `x86_64-apple-darwin` targets are added (`rustup target add ...`). CI does this in the `dtolnay/rust-toolchain` step.
 - **Updater silent on sideloaded copies** — sideloaded installs have a different bundle identifier; only the official MSI/DMG/AppImage receive update prompts.
 
+## Known advisories
+
+- **`glib` (GHSA-wrw7-89jp-8q8g, medium, Linux-only)** — accepted, no upstream fix available. The gtk-rs binding stack is pinned at `glib 0.18` by the latest `webkit2gtk` crate (2.0.2, which requires `glib ^0.18`) and by `tao`/`wry` (`gtk ^0.18`). The patched `glib 0.20` needs a gtk-rs 0.20 stack that no released Tauri 2.x ships, and Tauri 3 is not out yet. Only the **Linux** build links glib (Windows uses WebView2, macOS uses Cocoa), and the app does not exercise the affected API, so the Dependabot alert is dismissed as *tolerable risk*. Re-check when `tauri`/`wry`/`webkit2gtk` adopt gtk-rs 0.20, then `cargo update` and re-enable the alert.
+
 ## Related
 
 - [`../../docs/dev_env.md`](../../docs/dev_env.md) — IDE + toolchain

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/components/charts/EChart.tsx
+++ b/web/src/components/charts/EChart.tsx
@@ -16,7 +16,11 @@ import {
   VisualMapComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
-import ReactEChartsCore from "echarts-for-react/lib/core";
+// ESM build (esm/), NOT lib/ (CommonJS): under Vite 8 / Rolldown the CJS
+// default-interop wrapped lib/core's `module.exports = class` into a
+// namespace object, so `<ReactEChartsCore/>` rendered an object → React
+// error #130. The esm/ build has a clean `export default`, fixing it.
+import ReactEChartsCore from "echarts-for-react/esm/core";
 import { useMemo } from "react";
 import type { EChartsCoreOption } from "echarts/core";
 import "echarts-wordcloud";


### PR DESCRIPTION
## Vấn đề

Sau hotfix deploy Vite 8 / Rolldown ([#95](https://github.com/poli0981/free-steam-games-list/pull/95)), **mọi tab biểu đồ ném React error #130** ("Element type is invalid... got: object") và không render — toàn bộ `pages/charts/*` + Dashboard. Đây là regression LIVE trên production.

## Root cause

[EChart.tsx](web/src/components/charts/EChart.tsx) import wrapper từ `echarts-for-react/lib/core` (build **CommonJS**). Dưới Rolldown, CJS default-interop bọc `module.exports = class` thành namespace object → `<ReactEChartsCore/>` nhận object thay vì component → #130. (echarts core + echarts-wordcloud đã là ESM nên không dính.)

## Fix

Đổi sang build **ESM** `echarts-for-react/esm/core` (có `export default` sạch). 1 dòng, giữ nguyên API.

## Verify (runtime, trên bản build Rolldown — bước bị bỏ sót ở #95)

`npm run preview` + duyệt qua app bằng Preview MCP:
- ✅ Bar / pie-donut / line / treemap / heatmap / wordcloud đều render (Time: 3 canvas, Dashboard: 3, các tab khác: 1 mỗi tab).
- ✅ **Console 0 lỗi**, không còn React #130.
- ✅ Games / Settings / About OK; `echarts`/`openpgp` vẫn lazy async chunk (không eager-preload).
- ✅ typecheck, build, build:desktop, knip, `npm audit` (0 vulnerabilities) đều pass.

## glib advisory (GHSA-wrw7-89jp-8q8g)

**Không fix được trong Tauri 2.x**: `webkit2gtk` 2.0.2 (mới nhất) khoá `glib ^0.18`, `tao`/`wry` khoá `gtk ^0.18`, Tauri 3 chưa ra. Chỉ ảnh hưởng **Linux desktop** (Windows=WebView2, macOS=Cocoa), app không gọi API dính lỗi. Alert sẽ được dismiss (tolerable risk); ghi chú trong [TAURI.md](web/src-tauri/TAURI.md) để revisit khi upstream lên gtk-rs 0.20.

## Version

repo `3.4.0 → 3.4.1`; web + desktop `1.4.0 → 1.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)