### PR TITLE
docs(web): describe v3.4.1 build stack as Vite 8 + Rolldown

### DIFF
--- a/docs/ACKNOWLEDGEMENTs.md
+++ b/docs/ACKNOWLEDGEMENTs.md
@@ -33,7 +33,7 @@ The web app + desktop wrapper depend on a longer list, all linked with their lic
 **Runtime & build**
 - [React 18](https://react.dev/) + [react-dom](https://react.dev/) — UI runtime (MIT).
 - [TypeScript 5](https://www.typescriptlang.org/) — type system (Apache-2.0).
-- [Vite 7](https://vitejs.dev/) + [`@vitejs/plugin-react`](https://github.com/vitejs/vite-plugin-react) — build + dev server (MIT).
+- [Vite 8](https://vitejs.dev/) + [`@vitejs/plugin-react`](https://github.com/vitejs/vite-plugin-react) — build + dev server, powered by the [Rolldown](https://rolldown.rs/) bundler (MIT).
 - [PostCSS](https://postcss.org/) + [autoprefixer](https://github.com/postcss/autoprefixer) — CSS post-processing (MIT).
 
 **Styling**

--- a/web/README.md
+++ b/web/README.md
@@ -4,7 +4,7 @@ Static web UI for browsing, analyzing, and (soon) editing the F2P games dataset 
 
 ## Stack
 
-- **Vite + React 18 + TypeScript**
+- **Vite 8 (Rolldown bundler) + React 18 + TypeScript**
 - **Tailwind CSS** + shadcn/ui (Radix) primitives
 - **TanStack Query** (data fetching) + **TanStack Virtual** (1,200+ row table)
 - **Apache ECharts** (treemap, donut, bar, etc.)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",

--- a/web/src/gpgauth/README.md
+++ b/web/src/gpgauth/README.md
@@ -3,8 +3,8 @@
 This folder was added to host a local copy of OpenPGP.js so the web app could
 ship without a runtime npm dependency. **It is not currently used** — the
 single `openpgp.min.mjs` file split-codes its lazy chunks (`noble_curves.min.mjs`,
-`noble_hashes.min.mjs`, …) which weren't dropped alongside it, so Rollup
-fails to resolve them at build time.
+`noble_hashes.min.mjs`, …) which weren't dropped alongside it, so Rolldown
+(Vite 8's bundler) fails to resolve them at build time.
 
 The app now imports `openpgp` from the npm package instead, in
 [`src/lib/gpg.ts`](../lib/gpg.ts). The npm bundle is fully self-contained

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -68,7 +68,8 @@ interface Dep {
 const DEPS: Dep[] = [
   { name: "React 18", role: "UI runtime", href: "https://react.dev/", license: "MIT", licenseHref: "https://github.com/facebook/react/blob/main/LICENSE" },
   { name: "TypeScript 5", role: "type system", href: "https://www.typescriptlang.org/", license: "Apache-2.0", licenseHref: "https://github.com/microsoft/TypeScript/blob/main/LICENSE.txt" },
-  { name: "Vite 7", role: "build + dev server", href: "https://vitejs.dev/", license: "MIT", licenseHref: "https://github.com/vitejs/vite/blob/main/LICENSE" },
+  { name: "Vite 8", role: "build + dev server (Rolldown)", href: "https://vitejs.dev/", license: "MIT", licenseHref: "https://github.com/vitejs/vite/blob/main/LICENSE" },
+  { name: "Rolldown", role: "Rust bundler powering Vite 8", href: "https://rolldown.rs/", license: "MIT", licenseHref: "https://github.com/rolldown/rolldown/blob/main/LICENSE" },
   { name: "Tailwind CSS 3", role: "styling", href: "https://tailwindcss.com/", license: "MIT", licenseHref: "https://github.com/tailwindlabs/tailwindcss/blob/main/LICENSE" },
   { name: "Radix UI", role: "headless UI primitives", href: "https://www.radix-ui.com/", license: "MIT", licenseHref: "https://github.com/radix-ui/primitives/blob/main/LICENSE" },
   { name: "react-router-dom", role: "client-side routing", href: "https://reactrouter.com/", license: "MIT", licenseHref: "https://github.com/remix-run/react-router/blob/main/LICENSE.md" },


### PR DESCRIPTION
Docs/content cleanup follow-up to **v3.4.1**. The web build migrated from **Vite 7 (rollup + esbuild)** to **Vite 8**, which uses the **Rolldown** bundler — `esbuild` and standalone `rollup` are no longer in the dependency tree. This brings the stack/dependency documentation in line with reality, and syncs a stale lockfile version field left over from the v3.4.1 bump.

## Changes
- **`docs/ACKNOWLEDGEMENTs.md`** — Runtime & build list: `Vite 7` → `Vite 8`, now noted as *powered by the Rolldown bundler*.
- **`web/src/pages/About.tsx`** — in-app **About → Stack & third-party** list: `Vite 7` → `Vite 8 (Rolldown)`, plus a new **Rolldown** row (MIT, https://rolldown.rs/).
- **`web/README.md`** — Stack line → `Vite 8 (Rolldown bundler) + React 18 + TypeScript`.
- **`web/src/gpgauth/README.md`** — stale `Rollup` bundler note → `Rolldown (Vite 8's bundler)`.
- **`web/package-lock.json`** — sync `version` field `1.4.0` → `1.4.1` (the v3.4.1 bump updated `package.json` but not the lockfile, so `npm install` kept re-touching it). Only the two version lines change; dependency graph untouched.

## Scope / non-goals
- Docs & in-app copy + a one-field lockfile sync. **No** source logic, **no** canonical version bump (`package.json` / `Cargo.toml` / `tauri.conf.json` stay at the already-released `1.4.1` / `3.4.1`), **no** CHANGELOG history touched. No new version tag needed — this only aligns the lockfile to the shipped `1.4.1`.
- Historical `rollup`/`esbuild`/`1.4.0`/`3.4.0` mentions in `CHANGELOG.md` and the still-real `rollup-plugin-visualizer` devDependency left intact.
- `React 18` / `TypeScript 5` / `Tailwind CSS 3` already match `web/package.json`; `echarts-for-react` is listed without a version, so nothing to reconcile there.

## Verification
- `npm run typecheck` ✓
- `npm run build` ✓ (Vite 8.0.16 / Rolldown — `rolldown-runtime` chunk emitted)
- `npm run knip` — only pre-existing unused exports in `src/lib/*`; no new warnings.
- `npm install` after the lockfile edit → no further changes (lockfile now in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
