### PR TITLE
feat(android): touch-zoom charts + in-app update check

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.4.1"
+version = "1.4.2"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/components/charts/EChart.tsx
+++ b/web/src/components/charts/EChart.tsx
@@ -41,6 +41,40 @@ echarts.use([
   CanvasRenderer,
 ]);
 
+// Touch devices (phones, the Android webview) report `pointer: coarse`. Only
+// there do we add an inside dataZoom, so many-category charts can be pinch-
+// zoomed/panned. Desktop (`pointer: fine`) is left untouched — no mouse-wheel
+// zoom hijacking the page scroll.
+const IS_TOUCH =
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(pointer: coarse)").matches;
+
+function axisType(axis: unknown): string | undefined {
+  if (Array.isArray(axis)) return (axis[0] as { type?: string } | undefined)?.type;
+  return (axis as { type?: string } | undefined)?.type;
+}
+
+/**
+ * On touch, give cartesian charts an inside dataZoom on their *category* axis
+ * (the one prone to cramped ticks). No-op for pie/treemap/wordcloud (no axes)
+ * and for charts that already declare a dataZoom of their own.
+ */
+function withTouchZoom(option: EChartsCoreOption): EChartsCoreOption {
+  if (!IS_TOUCH) return option;
+  const o = option as Record<string, unknown>;
+  if (o.dataZoom) return option;
+  if (!o.xAxis && !o.yAxis) return option; // pie / treemap / wordcloud
+  const yIsCategory = axisType(o.yAxis) === "category";
+  const xIsCategory = axisType(o.xAxis) === "category";
+  // Horizontal bars carry the category on Y; everything else on X.
+  const zoom =
+    yIsCategory && !xIsCategory
+      ? { type: "inside", yAxisIndex: 0, filterMode: "none" }
+      : { type: "inside", xAxisIndex: 0, filterMode: "none" };
+  return { ...option, dataZoom: [zoom] };
+}
+
 interface Props {
   option: EChartsCoreOption;
   height?: number | string;
@@ -50,7 +84,7 @@ interface Props {
 export function EChart({ option, height = 360, className }: Props) {
   const opts = useMemo(
     () => ({
-      ...option,
+      ...withTouchZoom(option),
       backgroundColor: "transparent",
       textStyle: {
         fontFamily: "Inter, system-ui, sans-serif",

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -10,9 +10,11 @@ import { LoadingState } from "../common/QueryState";
 import { ErrorPage } from "../../pages/errors/ErrorPage";
 import { isChunkLoadError } from "../../lib/lazy";
 import { useGpgAutolock } from "../../hooks/useGpgAutolock";
+import { useAndroidUpdateCheck } from "../../hooks/useAndroidUpdateCheck";
 
 export function Layout() {
   useGpgAutolock();
+  useAndroidUpdateCheck();
   const { t } = useTranslation();
   const location = useLocation();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);

--- a/web/src/hooks/useAndroidUpdateCheck.ts
+++ b/web/src/hooks/useAndroidUpdateCheck.ts
@@ -1,0 +1,41 @@
+// Once-per-session check (Android only) for a newer APK on GitHub Releases.
+// Shows a persistent toast with a download action. No-op off Android/Tauri;
+// desktop relies on the native Tauri updater, web/PWA on the service worker.
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { isTauri, isAndroid, openExternal } from "../lib/external-open";
+import { checkAndroidUpdate } from "../lib/android-update";
+
+export function useAndroidUpdateCheck() {
+  const { t } = useTranslation();
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    if (!isTauri() || !isAndroid()) return;
+    ran.current = true;
+
+    let cancelled = false;
+    void checkAndroidUpdate()
+      .then((upd) => {
+        if (cancelled || !upd) return;
+        toast.info(t("appUpdate.available", { version: upd.version }), {
+          description: t("appUpdate.body"),
+          duration: Infinity,
+          action: {
+            label: t("appUpdate.download"),
+            onClick: () => void openExternal(upd.url),
+          },
+        });
+      })
+      .catch(() => {
+        /* network / rate-limit — silent, it's a best-effort nicety */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -89,6 +89,11 @@
     "installed": "Installed",
     "installedBody": "F2P Tracker is now available as a standalone app."
   },
+  "appUpdate": {
+    "available": "New version available ({{version}})",
+    "body": "Tap to download the latest APK from GitHub Releases.",
+    "download": "Download"
+  },
   "dashboard": {
     "title": "Dashboard",
     "subtitle": "Overview of {{count}} F2P Steam games tracked in this repository.",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -89,6 +89,11 @@
     "installed": "Đã cài",
     "installedBody": "F2P Tracker giờ chạy được như app riêng."
   },
+  "appUpdate": {
+    "available": "Có bản mới ({{version}})",
+    "body": "Chạm để tải APK mới nhất từ GitHub Releases.",
+    "download": "Tải về"
+  },
   "dashboard": {
     "title": "Tổng quan",
     "subtitle": "Tổng hợp {{count}} game F2P trên Steam được track trong repo.",

--- a/web/src/lib/android-update.ts
+++ b/web/src/lib/android-update.ts
@@ -1,0 +1,73 @@
+// Android in-app update check. The Tauri updater plugin is desktop-only, so on
+// Android we poll GitHub Releases for a newer `android-v*` tag and point the
+// user at the APK. Returns null when up to date or on any error (callers stay
+// silent — this is a best-effort nicety, not a critical path).
+
+import { REPO_OWNER, REPO_NAME } from "./schema";
+import { loadAuth } from "./github-api";
+
+const API_BASE = "https://api.github.com";
+
+export interface AndroidUpdate {
+  /** Bare version, e.g. "1.4.2". */
+  version: string;
+  /** Release page to open for the download. */
+  url: string;
+}
+
+interface GhRelease {
+  tag_name: string;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+function parseVer(v: string): number[] {
+  return v
+    .replace(/^android-v/i, "")
+    .split(".")
+    .map((n) => parseInt(n, 10) || 0);
+}
+
+/** Numeric semver-ish compare: is `a` strictly newer than `b`? */
+function isNewer(a: string, b: string): boolean {
+  const pa = parseVer(a);
+  const pb = parseVer(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d > 0;
+  }
+  return false;
+}
+
+export async function checkAndroidUpdate(): Promise<AndroidUpdate | null> {
+  const current = __APP_VERSION__;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  // Use the signed-in token if present (raises the API rate limit); the
+  // releases list is public so an anonymous call works too.
+  const token = loadAuth().token;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(
+    `${API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=30`,
+    { headers },
+  );
+  if (!res.ok) return null;
+  const releases = (await res.json()) as GhRelease[];
+
+  // Highest published android-v* release.
+  let best: { ver: string; url: string } | null = null;
+  for (const r of releases) {
+    if (r.draft || r.prerelease) continue;
+    if (!/^android-v/i.test(r.tag_name)) continue;
+    const ver = r.tag_name.replace(/^android-v/i, "");
+    if (!best || isNewer(ver, best.ver)) best = { ver, url: r.html_url };
+  }
+
+  return best && isNewer(best.ver, current)
+    ? { version: best.ver, url: best.url }
+    : null;
+}

--- a/web/src/lib/external-open.ts
+++ b/web/src/lib/external-open.ts
@@ -14,6 +14,14 @@ export function isTauri(): boolean {
   );
 }
 
+/** Running on Android (used to gate the Android-only in-app update check — the
+ *  Tauri updater plugin is desktop-only). */
+export function isAndroid(): boolean {
+  return (
+    typeof navigator !== "undefined" && /Android/i.test(navigator.userAgent)
+  );
+}
+
 export async function openExternal(url: string): Promise<void> {
   if (isTauri()) {
     try {

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -8,3 +8,6 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/** App version injected from package.json at build time (see vite.config.ts). */
+declare const __APP_VERSION__: string;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,11 +3,20 @@ import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "node:path";
+import { readFileSync } from "node:fs";
 
 const repoName = "free-steam-games-list";
+// Version sourced from package.json (single source of truth, matches the Android
+// versionName) and exposed to the bundle as `__APP_VERSION__` for the update check.
+const appVersion = JSON.parse(
+  readFileSync(path.resolve(__dirname, "package.json"), "utf-8"),
+).version as string;
 
 export default defineConfig(({ command, mode }) => ({
   base: command === "build" ? `/${repoName}/` : "/",
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   plugins: [
     react(),
     // `npm run analyze` → dist/stats.html treemap. Vite mode instead of an


### PR DESCRIPTION
Two follow-ups on top of the Android APK work (PR #100).

## ECharts touch-zoom (mobile)
Centralized in `EChart.tsx`: on touch devices (`pointer: coarse`) every cartesian chart gets an `inside` dataZoom on its **category** axis, so cramped many-category bar/line/heatmap charts (TopOnline/Offline, histograms, AddedPerMonth, cumulative line, AntiCheat, languages heatmap, …) can be pinch-zoomed and panned. Desktop (`pointer: fine`) is untouched — no mouse-wheel zoom hijacking the page scroll. Pie/treemap/wordcloud (no axes) are skipped. One file, ~10 charts covered, no per-chart edits.

## In-app update check (Android)
`tauri-plugin-updater` is desktop-only, so on Android the app checks GitHub Releases once per launch for a newer `android-v*` tag and shows a toast linking to the new APK.
- Exposes `package.json` version to the bundle as `__APP_VERSION__` (Vite `define`).
- New: `lib/android-update.ts` (version compare + releases fetch), `hooks/useAndroidUpdateCheck.ts` (mounted in Layout, Android+Tauri only), `isAndroid()` helper, `appUpdate` i18n keys (en/vi).
- Desktop keeps the native updater; web/PWA keeps the service-worker prompt — each platform uses its own mechanism.

## Verification
- ✅ typecheck + web build pass; `__APP_VERSION__` is replaced at build time (no literal left in `dist/`).
- Goes live in the next `android-v*` release (and benefits desktop/web charts too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)