### PR TITLE
feat(android): status-bar appearance + Kotlin cross-drive build fix (v1.4.3)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.4.2"
+version = "1.4.3"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/gen/android/app/src/main/res/values-night/themes.xml
+++ b/web/src-tauri/gen/android/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,13 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.f2p_tracker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+        <!-- Mirror values/themes.xml: transparent system bars + light icons for
+             the dark-by-default web UI under edge-to-edge (targetSdk 36). -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
+        <item name="android:enforceStatusBarContrast" tools:targetApi="29">false</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="29">false</item>
     </style>
 </resources>

--- a/web/src-tauri/gen/android/app/src/main/res/values/themes.xml
+++ b/web/src-tauri/gen/android/app/src/main/res/values/themes.xml
@@ -1,6 +1,16 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Theme.f2p_tracker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+        <!-- Edge-to-edge (targetSdk 36): keep the system bars transparent and use
+             light icons to match the app's dark-by-default chrome. The web UI
+             paints its own background behind them via the safe-area insets in
+             Layout. (If the user picks the light in-app theme the status-bar
+             icons sit on a light strip — a minor, accepted trade-off.) -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
+        <item name="android:enforceStatusBarContrast" tools:targetApi="29">false</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="29">false</item>
     </style>
 </resources>

--- a/web/src-tauri/gen/android/gradle.properties
+++ b/web/src-tauri/gen/android/gradle.properties
@@ -22,3 +22,11 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false
+# Kotlin incremental compilation relativizes its cache paths against the project
+# root; when the Cargo registry (e.g. C:\) and the project (e.g. E:\) sit on
+# different drives on Windows, that relativization throws and Kotlin falls back
+# to a slow non-incremental compile (with a noisy stack trace) every build.
+# Disabling incremental avoids the buggy path. The Kotlin surface here is tiny
+# (generated activity + Tauri plugin), so the cost is negligible; harmless on
+# single-drive CI.
+kotlin.incremental=false

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",


### PR DESCRIPTION
Two follow-ups, released as **v1.4.3**.

## Status-bar appearance
`themes.xml` (both `values/` and `values-night/`): under edge-to-edge (targetSdk 36) keep the system bars transparent and use **light status/nav icons** to match the app's dark-by-default chrome, with contrast enforcement off. The web UI paints its own background behind the bars via the Layout safe-area insets. (Picking the light in-app theme puts the icons on a light strip — a minor, accepted trade-off; a JS→native bridge would be needed to flip them per in-app theme.)

## Kotlin cross-drive build fix
`gradle.properties`: `kotlin.incremental=false`. When the Cargo registry (`C:\`) and the project (`E:\`) live on different drives on Windows, Kotlin's incremental cache path relativization throws and falls back to a slow non-incremental compile (with a noisy stack trace) every build. Disabling incremental avoids the buggy path entirely. The Kotlin surface is tiny (generated activity + Tauri plugin), so the cost is negligible; harmless on single-drive CI.

## Release
Bumped to **1.4.3** (versionCode 1004003) across the six version slots.

## Verification
- ✅ Debug APK builds; the Kotlin "different roots" error is **gone** (confirmed locally).
- ✅ No theme/resource compile errors.
- Status-bar appearance is a runtime/device check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)