### PR TITLE
feat(android): minSdk → Android 11 (API 30) + hide Steam Desktop on mobile, v1.4.4

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -129,7 +129,12 @@ jobs:
             3. Updates: install a newer APK over the top — same signing key, so no
                uninstall needed.
 
-            Min Android 7.0 (API 24). Reads data live from `raw.githubusercontent.com`;
-            no telemetry. See `docs/DISCLAIMER.md` for accuracy caveats.
+            **Requires Android 11 (API 30) or newer** — older devices are blocked
+            at install (`INSTALL_FAILED_OLDER_SDK`). Why this floor + worldwide
+            version stats: `docs/android-support.md`. Tested on emulator 11–16 and
+            a real vivo 1907 (Android 12).
+
+            Reads data live from `raw.githubusercontent.com`; no telemetry. See
+            `docs/DISCLAIMER.md` for accuracy caveats.
 
             Built from commit `${{ github.sha }}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this awesome noob repo will be documented here.
 
+## [v3.4.2] – 2026-06-15 (The "Android Floor" Edition)
+
+Android-focused release that raises the APK's minimum OS, hides a desktop-only
+affordance on phones, and documents the support policy with sourced numbers. Web
+app + desktop/Android bumped `1.4.3` → `1.4.4`; repo public-facing version
+`3.4.1` → `3.4.2`. Tag `v3.4.2` is GPG-signed; the Android APK ships from
+`android-v1.4.4`.
+
+### 🤖 Minimum Android raised to 11 (API 30)
+
+- [build.gradle.kts](web/src-tauri/gen/android/app/build.gradle.kts) `minSdk` `24` → `30`. Android's package installer refuses to install the APK below this (`INSTALL_FAILED_OLDER_SDK`), so the version floor doubles as the OS-level install gate — no in-app check, no bypass. Don't re-run `tauri android init` (it would reset it).
+- **Why 11, not lower:** Android 7–10 are deeply end-of-life — Google ships OS security backports only for 14/15/16 as of mid-2026 — and tend to carry an outdated System WebView that breaks the modern ES2022 / React 19 output of the Vite 8 / Rolldown bundle. A `minSdk 30` floor still reaches ~87% of active Android devices (StatCounter, May 2026) while dropping only the dead tail. Android 11–13 install but no longer get Google OS patches — called out explicitly in the docs.
+
+### 📱 "Steam Desktop" button hidden on mobile
+
+- The `steam://` "Steam Desktop" button in [GameDetailDrawer.tsx](web/src/components/games/GameDetailDrawer.tsx) can't reach a Steam client on a phone, so it's now hidden on the Android app **or** a sub-768px viewport; the "Web" button stays. Gated by a new reactive [useIsMobile.ts](web/src/hooks/useIsMobile.ts) hook (`useSyncExternalStore` + `matchMedia("(max-width: 767px)")`, OR the existing `isAndroid()` from [external-open.ts](web/src/lib/external-open.ts)) — re-renders on resize / rotation. No new i18n strings.
+
+### 📚 Docs & transparency
+
+- New [docs/android-support.md](docs/android-support.md) (+ Vietnamese mirror [i18n/vi/android-support.md](docs/i18n/vi/android-support.md)): minimum requirement, full rationale (security/EOL, WebView/React compatibility, edge-to-edge), tested-device matrix (emulator Android 11→16, real **vivo 1907** on Android 12), and a worldwide version-share + security-EOL table with **cited sources** ([apilevels.com](https://apilevels.com/), [StatCounter](https://gs.statcounter.com/android-version-market-share/mobile/worldwide/), [endoflife.date](https://endoflife.date/android), [Android Security Bulletins](https://source.android.com/docs/security/bulletin)). Reused as the GitHub Discussion announcement.
+- Updated [TAURI.md](web/src-tauri/TAURI.md), [pc_spec.md](docs/pc_spec.md) (+ VN mirror) with the new Android test-device section, the [release-android.yml](.github/workflows/release-android.yml) release-notes template, and the [README](README.md) (version badge `3.4.1`→`3.4.2`, new Android 11+ badge + Quick-links row).
+
 ## [v3.4.1] – 2026-06-14 (The "Chart Hotfix" Edition)
 
 Patch release fixing a production regression introduced by the Vite 8 / Rolldown deploy hotfix (#95): every chart tab threw a blank **React error #130** and failed to render. Web app + desktop bumped `1.4.0` → `1.4.1`; repo public-facing version `3.4.0` → `3.4.1`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 [![Games Count](https://img.shields.io/badge/Games-1.2k%2B-green?style=flat&logo=steam)](games/all-games_part1.md)
 [![Last Updated](https://img.shields.io/badge/Updated-Daily-blue?style=flat&logo=github-actions)](.github/workflows)
 [![Top Online](https://img.shields.io/badge/Top%20Online-Live%20Leaderboard-red?style=flat&logo=steam)](games/top-online.md)
-[![Version](https://img.shields.io/badge/version-3.4.1-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
+[![Version](https://img.shields.io/badge/version-3.4.2-purple?style=flat&logo=github)](https://github.com/poli0981/free-steam-games-list)
 [![Web App](https://img.shields.io/badge/Web%20App-Live-2563eb?style=flat&logo=react)](https://poli0981.github.io/free-steam-games-list/)
 [![Desktop](https://img.shields.io/badge/Desktop-Tauri%202-FFC131?style=flat&logo=tauri)](https://github.com/poli0981/free-steam-games-list/releases)
+[![Android](https://img.shields.io/badge/Android-11%2B%20APK-3DDC84?style=flat&logo=android)](https://github.com/poli0981/free-steam-games-list/releases)
 [![Health Check](https://img.shields.io/badge/Health%20Check-Weekly-orange?style=flat&logo=github-actions)](.github/workflows/purge-unhealthy.yml)
 ![Visitors](https://visitor-badge.laobi.icu/badge?page_id=poli0981.free-steam-games-list)
 [![Sponsor](https://img.shields.io/badge/Sponsor-Buy%20me%20a%20coffee-ff5f5f?style=flat&logo=buy-me-a-coffee)](.github/FUNDING.yml)
@@ -26,6 +27,7 @@ A **curated list** of free-to-play games on Steam — now ~1,200 of them — no 
 | -------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | 🌐 Web app          | <https://poli0981.github.io/free-steam-games-list/>                                                                  |
 | 🖥️ Desktop releases  | [GitHub Releases](https://github.com/poli0981/free-steam-games-list/releases) (Win `.msi`, Mac `.dmg`, Linux `.AppImage`) |
+| 📱 Android APK      | [GitHub Releases](https://github.com/poli0981/free-steam-games-list/releases) (sideload `.apk`, **Android 11+** — see [`docs/android-support.md`](docs/android-support.md)) |
 | 📋 All games (md)   | [games/all-games_part1.md](games/all-games_part1.md) (sorted by reviews)                                             |
 | 🏆 Top online (md)  | [games/top-online.md](games/top-online.md)                                                                           |
 | 🎯 Top offline (md) | [games/top-offline.md](games/top-offline.md)                                                                         |

--- a/docs/android-support.md
+++ b/docs/android-support.md
@@ -1,0 +1,85 @@
+# Android support & system requirements
+
+> Mirrored in Vietnamese at [`i18n/vi/android-support.md`](i18n/vi/android-support.md).
+
+This document explains the **minimum Android version** the F2P Tracker APK
+requires, **why**, and **what we test on**. Numbers are sourced so you can check
+them yourself.
+
+## Minimum requirement
+
+| | |
+| --- | --- |
+| **Minimum** | **Android 11 (API level 30)** or newer |
+| **Target / compiled against** | Android 16 (API 36) |
+| **CPU/ABI** | universal APK — `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64` |
+
+The APK declares `minSdkVersion 30`. On a device older than Android 11, Android's
+package installer **refuses to install** it (`INSTALL_FAILED_OLDER_SDK`) and shows
+*"App not installed"* / *"requires a newer version of Android"*. This is enforced
+by the OS itself — there is no in-app bypass — so the version floor is also the
+install gate. (Set in [`gen/android/app/build.gradle.kts`](../web/src-tauri/gen/android/app/build.gradle.kts) → `minSdk = 30`.)
+
+## Why Android 11+
+
+1. **Security / end-of-life.** Google only ships OS-level security backports for
+   the latest releases. As of June 2026 that is **Android 14, 15 and 16** only —
+   Android 13 left the security bulletins around March 2026, Android 12/12L on
+   31 March 2025, and Android 11 and older are long past it. We set the floor at
+   **11** rather than 14 as a deliberate balance: it removes the *deeply* dead
+   tail (Android 7–10) while still covering the large installed base on 11–13.
+   **Be aware:** Android 11–13 no longer receive OS security patches from Google,
+   even though they can still install the app.
+2. **WebView / React compatibility.** The app is a thin native shell around the
+   web UI; everything renders in the **Android System WebView** (Chromium). Old
+   Android releases tend to carry an outdated WebView, which can choke on the
+   modern ES2022 / React 19 output of our Vite 8 / Rolldown build. A newer OS
+   floor raises the guaranteed Chromium baseline and reduces that breakage risk.
+   (The WebView itself updates independently via the Play Store, so users who
+   keep it current fare better — but we can't rely on that on EOL devices.)
+3. **Edge-to-edge & safe areas.** We compile against `targetSdk 36` (Android 16),
+   which forces edge-to-edge layout; the UI uses `env(safe-area-inset-*)` to dodge
+   the status / gesture-nav bars. These behave most reliably on Android 11+.
+4. **Tested surface.** We only test from Android 11 upward (see below); we don't
+   want to ship a floor we can't smoke-test.
+
+## Tested devices
+
+| Type | Device / target | Android version |
+| --- | --- | --- |
+| Emulator | Android Studio AVD | **Android 11 → 16** (API 30–36) |
+| Real phone | **vivo 1907** | **Android 12** (API 31) |
+
+Anything below Android 11 is unsupported and blocked at install time. Anything
+above is expected to work but is best-effort beyond the matrix above. Found a
+problem? File a [bug report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml)
+with device + Android version + screenshot.
+
+## Android version landscape (the data behind the decision)
+
+Worldwide Android version share and security-support status, mid-2026:
+
+| Android | API | Google OS security patches? | Share (StatCounter, May 2026) | Cumulative (this version or newer) |
+| --- | --- | --- | --- | --- |
+| 16 (Baklava) | 36 | ✅ supported | 23.1% | 22.3% |
+| 15 | 35 | ✅ supported | 18.1% | 41.0% |
+| 14 | 34 | ✅ supported | 13.0% | 54.5% |
+| 13 | 33 | ❌ EOL ~Mar 2026 | 14.3% | 68.9% |
+| 12 / 12L | 31 / 32 | ❌ EOL 31 Mar 2025 | 10.0% | 78.8% |
+| **11** | **30** | ❌ EOL ~2023 | 7.9% | **86.9%** |
+| 10 and older | ≤ 29 | ❌ | remainder | — |
+
+A `minSdk 30` floor therefore reaches roughly **87% of active Android devices**
+while dropping only the long-dead tail.
+
+### Sources
+
+- API level ↔ version mapping and cumulative usage — [apilevels.com](https://apilevels.com/) (cumulative figures updated 28 May 2026 from April 2026 data).
+- Per-version market share — [StatCounter, Mobile Android Version, Worldwide](https://gs.statcounter.com/android-version-market-share/mobile/worldwide/) (May 2026).
+- Security end-of-life dates — [endoflife.date/android](https://endoflife.date/android) and the [Android Security Bulletins](https://source.android.com/docs/security/bulletin) (a release is treated as EOL once it stops appearing in the monthly bulletins).
+
+## Related
+
+- [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md) — Android build prerequisites + CI.
+- [`pc_spec.md`](pc_spec.md) — maintainer hardware + the full test-device list.
+- [`DISCLAIMER.md`](DISCLAIMER.md) — data-accuracy caveats.

--- a/docs/i18n/vi/android-support.md
+++ b/docs/i18n/vi/android-support.md
@@ -1,0 +1,82 @@
+# Hỗ trợ Android & yêu cầu hệ thống
+
+> Bản tiếng Anh ở [`../../android-support.md`](../../android-support.md).
+
+File này giải thích **phiên bản Android tối thiểu** mà APK F2P Tracker yêu cầu,
+**lý do**, và **những gì đã được test**. Số liệu đều có nguồn để bạn tự kiểm chứng.
+
+## Yêu cầu tối thiểu
+
+| | |
+| --- | --- |
+| **Tối thiểu** | **Android 11 (API 30)** trở lên |
+| **Target / compile** | Android 16 (API 36) |
+| **CPU/ABI** | APK universal — `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64` |
+
+APK khai báo `minSdkVersion 30`. Trên máy cũ hơn Android 11, trình cài đặt của
+Android **từ chối cài** (`INSTALL_FAILED_OLDER_SDK`) và báo *"App not installed"* /
+*"cần phiên bản Android mới hơn"*. Đây là cơ chế do chính OS thực thi — không có
+cách bypass trong app — nên ngưỡng phiên bản cũng chính là cổng chặn cài đặt.
+(Đặt tại [`gen/android/app/build.gradle.kts`](../../../web/src-tauri/gen/android/app/build.gradle.kts) → `minSdk = 30`.)
+
+## Vì sao Android 11+
+
+1. **Bảo mật / hết vòng đời (EOL).** Google chỉ vá bảo mật OS cho các bản mới
+   nhất. Tính đến 06/2026, chỉ còn **Android 14, 15 và 16** — Android 13 rời các
+   security bulletin khoảng 03/2026, Android 12/12L ngày 31/03/2025, còn Android
+   11 trở về trước thì đã EOL từ lâu. Chọn ngưỡng **11** thay vì 14 là cân bằng có
+   chủ đích: bỏ phần đuôi *chết hẳn* (Android 7–10) mà vẫn phủ lượng lớn người
+   dùng đang ở 11–13. **Lưu ý:** Android 11–13 không còn nhận bản vá bảo mật OS
+   từ Google, dù vẫn cài được app.
+2. **Tương thích WebView / React.** App là lớp vỏ native mỏng bọc UI web; mọi thứ
+   render trong **Android System WebView** (Chromium). Các bản Android cũ thường
+   mang WebView lỗi thời, dễ vỡ với output ES2022 / React 19 của bản build Vite 8
+   / Rolldown. Ngưỡng OS cao hơn nâng nền Chromium tối thiểu và giảm rủi ro này.
+   (WebView tự cập nhật độc lập qua Play Store, nên ai giữ nó mới thì ổn hơn —
+   nhưng không thể trông cậy điều đó trên máy đã EOL.)
+3. **Edge-to-edge & safe area.** Ta compile với `targetSdk 36` (Android 16), buộc
+   layout edge-to-edge; UI dùng `env(safe-area-inset-*)` để né thanh status /
+   gesture-nav. Những hành vi này ổn định nhất trên Android 11+.
+4. **Phạm vi test.** Ta chỉ test từ Android 11 trở lên (xem dưới); không muốn ship
+   một ngưỡng không thể smoke-test.
+
+## Thiết bị đã test
+
+| Loại | Thiết bị / target | Phiên bản Android |
+| --- | --- | --- |
+| Emulator | Android Studio AVD | **Android 11 → 16** (API 30–36) |
+| Máy thật | **vivo 1907** | **Android 12** (API 31) |
+
+Dưới Android 11 là không hỗ trợ và bị chặn ngay khi cài. Trên ngưỡng đó dự kiến
+chạy được nhưng là best-effort ngoài ma trận trên. Gặp lỗi? Mở
+[bug report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml)
+kèm thiết bị + phiên bản Android + screenshot.
+
+## Bức tranh phiên bản Android (dữ liệu đằng sau quyết định)
+
+Thị phần & trạng thái hỗ trợ bảo mật của các phiên bản Android toàn cầu, giữa 2026:
+
+| Android | API | Google còn vá bảo mật OS? | Thị phần (StatCounter, 5/2026) | Tích luỹ (bản này trở lên) |
+| --- | --- | --- | --- | --- |
+| 16 (Baklava) | 36 | ✅ còn | 23.1% | 22.3% |
+| 15 | 35 | ✅ còn | 18.1% | 41.0% |
+| 14 | 34 | ✅ còn | 13.0% | 54.5% |
+| 13 | 33 | ❌ EOL ~3/2026 | 14.3% | 68.9% |
+| 12 / 12L | 31 / 32 | ❌ EOL 31/3/2025 | 10.0% | 78.8% |
+| **11** | **30** | ❌ EOL ~2023 | 7.9% | **86.9%** |
+| 10 trở về trước | ≤ 29 | ❌ | phần còn lại | — |
+
+Vậy ngưỡng `minSdk 30` phủ khoảng **87% thiết bị Android đang hoạt động** mà chỉ
+bỏ phần đuôi đã chết.
+
+### Nguồn
+
+- Bảng API ↔ version + phủ tích luỹ — [apilevels.com](https://apilevels.com/) (số tích luỹ cập nhật 28/05/2026 từ dữ liệu 04/2026).
+- Thị phần từng bản — [StatCounter, Mobile Android Version, Worldwide](https://gs.statcounter.com/android-version-market-share/mobile/worldwide/) (5/2026).
+- Ngày EOL bảo mật — [endoflife.date/android](https://endoflife.date/android) và [Android Security Bulletins](https://source.android.com/docs/security/bulletin) (một bản coi là EOL khi không còn xuất hiện trong bulletin hằng tháng).
+
+## Liên quan
+
+- [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md) — yêu cầu build Android + CI.
+- [`pc_spec.md`](pc_spec.md) — phần cứng maintainer + danh sách thiết bị test.
+- [`../../DISCLAIMER.md`](../../DISCLAIMER.md) — lưu ý về độ chính xác dữ liệu.

--- a/docs/i18n/vi/pc_spec.md
+++ b/docs/i18n/vi/pc_spec.md
@@ -2,7 +2,7 @@
 
 File này ghi cấu hình máy mà maintainer (poli0981 / SkullMute) thực sự đang dùng để phát triển, build và test repo này. Bản tiếng Anh ở [`../../pc_spec.md`](../../pc_spec.md).
 
-Đây **không phải** yêu cầu hệ thống cho user — web app chạy trên mọi browser hiện đại, còn desktop app chỉ cần Tauri 2 platform deps (xem [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md)).
+Đây **không phải** yêu cầu hệ thống cho user — web app chạy trên mọi browser hiện đại, còn desktop app chỉ cần Tauri 2 platform deps (xem [`../../../web/src-tauri/TAURI.md`](../../../web/src-tauri/TAURI.md)). **APK Android** là bề mặt duy nhất có ngưỡng thật — **Android 11+** (xem [`android-support.md`](android-support.md)).
 
 ## Máy dev chính
 
@@ -25,6 +25,15 @@ Web app + desktop build được smoke-test trên:
 - **Desktop browser** — Chrome, Edge, Firefox, Brave (Windows 11)
 
 Ngoài danh sách trên là best-effort. Nếu render lỗi ở chỗ lạ, mở [bug report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml) — kèm browser + OS + screenshot.
+
+## Thiết bị test (app Android)
+
+APK sideload yêu cầu **Android 11 (API 30)** trở lên (máy cũ hơn bị chặn ngay khi cài). Đã smoke-test trên:
+
+- **Emulator** — Android Studio AVD, **Android 11 → 16** (API 30–36)
+- **Máy thật** — **vivo 1907**, Android 12 (API 31)
+
+Xem [`android-support.md`](android-support.md) để biết lý do chọn ngưỡng + thị phần các phiên bản Android.
 
 ## Liên quan
 

--- a/docs/pc_spec.md
+++ b/docs/pc_spec.md
@@ -2,7 +2,7 @@
 
 This file documents the hardware the maintainer (poli0981 / SkullMute) actually uses to develop, build, and test this repo. It is mirrored in Vietnamese at [`i18n/vi/pc_spec.md`](i18n/vi/pc_spec.md).
 
-It is **not** a system requirement for users — the web app runs in any modern browser, and the desktop app only needs the Tauri 2 platform deps (see [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md)).
+It is **not** a system requirement for users — the web app runs in any modern browser, and the desktop app only needs the Tauri 2 platform deps (see [`../web/src-tauri/TAURI.md`](../web/src-tauri/TAURI.md)). The **Android APK** is the one surface with a real floor — **Android 11+** (see [`android-support.md`](android-support.md)).
 
 ## Developer machine (primary)
 
@@ -25,6 +25,15 @@ The web app + desktop builds are smoke-tested on:
 - **Desktop browsers** — Chrome, Edge, Firefox, Brave (Windows 11)
 
 Anything outside this set is best-effort. File a [bug report](https://github.com/poli0981/free-steam-games-list/issues/new?template=bug_report.yml) if rendering breaks somewhere unusual — include browser + OS + screenshot.
+
+## Test devices (Android app)
+
+The sideloadable APK requires **Android 11 (API 30)** or newer (older devices are blocked at install time). Smoke-tested on:
+
+- **Emulator** — Android Studio AVD, **Android 11 → 16** (API 30–36)
+- **Real phone** — **vivo 1907**, Android 12 (API 31)
+
+See [`android-support.md`](android-support.md) for the minimum-version rationale + worldwide version stats.
 
 ## Related
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-steam-games-web",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-steam-games-web",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "free-steam-games-web",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.lock
+++ b/web/src-tauri/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "f2p-tracker"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "f2p-tracker"
-version = "1.4.3"
+version = "1.4.4"
 description = "Desktop wrapper around the Steam F2P Tracker web app"
 authors = ["poli0981"]
 license = "MIT"

--- a/web/src-tauri/TAURI.md
+++ b/web/src-tauri/TAURI.md
@@ -107,7 +107,7 @@ npm run tauri:android:dev                                     # run on emulator 
 npm run tauri -- android build --apk --debug --target aarch64 # fast debug build, single ABI
 ```
 
-Output: `gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk`. Minimum Android 7.0 (API 24).
+Output: `gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk`. Minimum **Android 11 (API 30)** — see [`docs/android-support.md`](../../docs/android-support.md) for the requirement + rationale.
 
 ### Signing
 
@@ -128,6 +128,7 @@ keytool -genkeypair -v -keystore f2p-tracker-release.jks \
 
 ### Notes
 
+- **Minimum Android 11 (API 30)** — `minSdk = 30` in [`gen/android/app/build.gradle.kts`](gen/android/app/build.gradle.kts). Android's installer blocks the APK below that (`INSTALL_FAILED_OLDER_SDK`), so it's also the OS-level version gate — no in-app check needed. Floor chosen for security (Android 7–10 are EOL with no Google OS patches and old WebViews) over raw reach; tested on emulator 11→16 + a real vivo 1907 (Android 12). Full rationale + version stats: [`docs/android-support.md`](../../docs/android-support.md). Don't re-run `tauri android init` — it would reset this.
 - **No auto-updater on Android** — `tauri-plugin-updater` is desktop-only. Updates are manual: install a newer APK over the top (same signing key → no uninstall).
 - **Edge-to-edge** — targetSdk 36 forces it; the layout uses `env(safe-area-inset-*)` to dodge the status / gesture-nav bars.
 - **OAuth Device Flow** routes through `@tauri-apps/plugin-http` because the Android System WebView enforces CORS on the `github.com/login/*` endpoints (desktop's webview doesn't). PAT sign-in needs no native bridge.

--- a/web/src-tauri/gen/android/app/build.gradle.kts
+++ b/web/src-tauri/gen/android/app/build.gradle.kts
@@ -30,7 +30,13 @@ android {
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "io.github.poli0981.f2p_tracker"
-        minSdk = 24
+        // Android 11 (API 30). PackageManager refuses to install the APK below
+        // this (INSTALL_FAILED_OLDER_SDK), so it doubles as the OS-level version
+        // gate. Why 11 and not lower: Android 7-10 are deeply end-of-life (no
+        // Google OS security backports) and tend to ship an outdated System
+        // WebView that breaks the app's modern ES/React 19 bundle. See
+        // docs/android-support.md for the rationale + version stats.
+        minSdk = 30
         targetSdk = 36
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "F2P Tracker",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "identifier": "io.github.poli0981.f2p-tracker",
   "build": {
     "beforeBuildCommand": "npm run build:desktop",

--- a/web/src/components/games/GameDetailDrawer.tsx
+++ b/web/src/components/games/GameDetailDrawer.tsx
@@ -33,6 +33,7 @@ import { preferWebp } from "../../lib/image";
 import type { GameRecord } from "../../lib/schema";
 import { EditGameDrawer } from "./EditGameDrawer";
 import { useIsOwner } from "../../hooks/useIsOwner";
+import { useIsMobile } from "../../hooks/useIsMobile";
 
 interface Props {
   game: GameRecord | null;
@@ -64,6 +65,9 @@ function Field({
 export function GameDetailDrawer({ game, onClose, missing }: Props) {
   const { t } = useTranslation();
   const isOwner = useIsOwner();
+  // The steam:// "Steam Desktop" button is desktop-only — it can't reach a
+  // Steam client on a phone. Hide it on the Android app / mobile viewport.
+  const isMobile = useIsMobile();
   const [editing, setEditing] = useState(false);
 
   return (
@@ -137,15 +141,17 @@ export function GameDetailDrawer({ game, onClose, missing }: Props) {
                       const web = appid ? steamWebUrl(appid) : game.link;
                       return (
                         <>
-                          <Button asChild size="sm" variant="default">
-                            <a
-                              href={protocol}
-                              title={t("detail.openOnSteamDesktopHint")}
-                            >
-                              <Monitor className="mr-1 h-3 w-3" />
-                              {t("detail.openOnSteamDesktop")}
-                            </a>
-                          </Button>
+                          {!isMobile && (
+                            <Button asChild size="sm" variant="default">
+                              <a
+                                href={protocol}
+                                title={t("detail.openOnSteamDesktopHint")}
+                              >
+                                <Monitor className="mr-1 h-3 w-3" />
+                                {t("detail.openOnSteamDesktop")}
+                              </a>
+                            </Button>
+                          )}
                           <Button asChild size="sm" variant="outline">
                             <a href={web} target="_blank" rel="noopener noreferrer">
                               <ExternalLink className="mr-1 h-3 w-3" />

--- a/web/src/hooks/useIsMobile.ts
+++ b/web/src/hooks/useIsMobile.ts
@@ -1,0 +1,31 @@
+import { useSyncExternalStore } from "react";
+import { isAndroid } from "../lib/external-open";
+
+// "Mobile" = the Android app (any size) OR a viewport below Tailwind's `md`
+// breakpoint (768px). matchMedia uses max-width 767px so it flips exactly where
+// the `md:` utility classes do.
+const QUERY = "(max-width: 767px)";
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(QUERY).matches;
+}
+
+/**
+ * True on Android (mobile webview, regardless of viewport) OR when the viewport
+ * is below the `md` (768px) breakpoint. Reactive — re-renders on resize /
+ * rotation via `matchMedia`. Used to hide desktop-only affordances such as the
+ * `steam://` "Steam Desktop" button. `isAndroid()` is a stable userAgent check,
+ * so it's OR-ed in without a subscription.
+ */
+export function useIsMobile(): boolean {
+  const narrow = useSyncExternalStore(subscribe, getSnapshot, () => false);
+  return narrow || isAndroid();
+}


### PR DESCRIPTION
## What & why

In-this-version Android pass — raise the install floor, drop a desktop-only affordance on phones, and document the support policy with sourced numbers.

### 🤖 Minimum Android raised to 11 (API 30)
- `web/src-tauri/gen/android/app/build.gradle.kts`: `minSdk 24 → 30`. Android''s installer blocks the APK below API 30 (`INSTALL_FAILED_OLDER_SDK`), so the floor is also the OS-level version gate — no in-app check, no bypass.
- **Why 11:** Android 7–10 are deeply EOL (Google ships OS security backports only for 14/15/16 as of mid-2026) and tend to carry an outdated System WebView that breaks the modern ES2022 / React 19 bundle. `minSdk 30` still reaches **~87%** of active devices (StatCounter, May 2026). Android 11–13 still install but no longer get Google OS patches — called out explicitly in the docs.

### 📱 "Steam Desktop" button hidden on mobile
- The `steam://` button in `GameDetailDrawer.tsx` can''t reach a Steam client on a phone → hidden on the Android app **or** a sub-768px viewport via a new reactive `useIsMobile` hook (`useSyncExternalStore` + `matchMedia` OR the existing `isAndroid()`). The "Web" button stays. No new i18n strings.

### 📚 Docs & transparency
- New `docs/android-support.md` (+ Vietnamese mirror): requirement, rationale (security/EOL, WebView/React, edge-to-edge), tested-device matrix (emulator 11→16, real **vivo 1907**/Android 12), and a worldwide version-share + EOL table with **cited sources** (apilevels.com, StatCounter, endoflife.date, Android Security Bulletins).
- Updated `TAURI.md`, `pc_spec.md` (+vi), `release-android.yml` notes, `README` (version badge `3.4.1→3.4.2`, new Android 11+ badge + Quick-links row).

### 🔖 Version
- `1.4.3 → 1.4.4` across `package.json` / `tauri.conf.json` / `Cargo.toml` + `Cargo.lock` / `package-lock.json` sync. Repo public version `3.4.1 → 3.4.2`.

## Verification
- `npm run typecheck` ✅ · `npm run build` (prod Rolldown) ✅ · `npm run knip` exit 0 (new hook referenced, no new dead export) · `npm ci` → 0 vulnerabilities.
- Android install-block only manifests in a built APK''s merged manifest → confirmed by the `android-v1.4.4` CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)